### PR TITLE
Core loop: evidence-graded cards, clarity-gated ladders, card story page

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,3 +5,7 @@ python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 python manage.py collectstatic --no-input
 python manage.py migrate --noinput
+# TEMPORARY (2026-07-09): one-time rebuild of ladder gate progress from historical
+# scoring jobs after the core-loop deploy. Idempotent, but remove this line once
+# the first deploy with it has gone out.
+python manage.py backfill_ladder_progress

--- a/docs/core-loop-plan.html
+++ b/docs/core-loop-plan.html
@@ -1,0 +1,573 @@
+<meta charset="utf-8">
+<title>SpeechPractice — Core Loop &amp; Implementation Plan</title>
+<style>
+  :root {
+    color-scheme: light;
+    --paper: #ffffff;
+    --ink: #1a242c;
+    --muted: #4e5e69;
+    --faint: #7c8a93;
+    --line: #dde4e7;
+    --panel: #f1f5f5;
+    --accent: #0b6f61;
+    --accent-soft: #e0eeeb;
+    --gate: #8f6210;
+    --gate-soft: #f5ecd9;
+    --pass: #27713c;
+    --code-bg: #eef2f2;
+    --serif: Charter, "Bitstream Charter", "Iowan Old Style", Georgia, serif;
+    --sans: "Segoe UI", system-ui, -apple-system, sans-serif;
+    --mono: "Cascadia Code", Consolas, "SF Mono", Menlo, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+      --paper: #10171c;
+      --ink: #eaf0f2;
+      --muted: #aab8c0;
+      --faint: #78878f;
+      --line: #2c3840;
+      --panel: #1a242b;
+      --accent: #47c2ad;
+      --accent-soft: #163530;
+      --gate: #e0b055;
+      --gate-soft: #362d18;
+      --pass: #6cc281;
+      --code-bg: #1d2830;
+    }
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --paper: #ffffff; --ink: #1a242c; --muted: #4e5e69; --faint: #7c8a93;
+    --line: #dde4e7; --panel: #f1f5f5; --accent: #0b6f61; --accent-soft: #e0eeeb;
+    --gate: #8f6210; --gate-soft: #f5ecd9; --pass: #27713c; --code-bg: #eef2f2;
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --paper: #10171c; --ink: #eaf0f2; --muted: #aab8c0; --faint: #78878f;
+    --line: #2c3840; --panel: #1a242b; --accent: #47c2ad; --accent-soft: #163530;
+    --gate: #e0b055; --gate-soft: #362d18; --pass: #6cc281; --code-bg: #1d2830;
+  }
+
+  html, body {
+    background: var(--paper);
+    color: var(--ink);
+  }
+  body {
+    font-family: var(--sans);
+    line-height: 1.6;
+    font-size: 16px;
+    margin: 0;
+  }
+  .page {
+    background: var(--paper);
+    color: var(--ink);
+    min-height: 100vh;
+  }
+  .page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 56px 24px 96px;
+  }
+
+  header.doc { margin-bottom: 56px; }
+  .eyebrow {
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 14px;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-size: 40px;
+    line-height: 1.15;
+    font-weight: 700;
+    margin: 0 0 16px;
+    text-wrap: balance;
+  }
+  .thesis {
+    font-family: var(--serif);
+    font-size: 19px;
+    color: var(--muted);
+    max-width: 40em;
+    margin: 0;
+  }
+  .thesis strong { color: var(--ink); font-weight: 600; }
+
+  h2 {
+    font-family: var(--serif);
+    font-size: 26px;
+    font-weight: 700;
+    margin: 64px 0 6px;
+    text-wrap: balance;
+  }
+  h2 .sec {
+    color: var(--faint);
+    font-family: var(--mono);
+    font-size: 15px;
+    font-weight: 400;
+    margin-right: 10px;
+  }
+  h3 {
+    font-size: 16.5px;
+    font-weight: 650;
+    margin: 32px 0 8px;
+  }
+  .lede { color: var(--muted); margin: 0 0 20px; max-width: 44em; }
+  p { max-width: 44em; }
+  ul { padding-left: 22px; max-width: 44em; }
+  li { margin: 6px 0; }
+  li::marker { color: var(--accent); }
+
+  code {
+    font-family: var(--mono);
+    font-size: 0.86em;
+    background: var(--code-bg);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+    overflow-x: auto;
+    font-family: var(--mono);
+    font-size: 13.5px;
+    line-height: 1.55;
+  }
+  pre code { background: none; padding: 0; }
+
+  /* ── Loop diagram ── */
+  .loop-wrap { overflow-x: auto; margin: 28px 0 8px; }
+  .loop {
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+    min-width: 640px;
+  }
+  .stage {
+    flex: 1;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 12px 14px;
+    position: relative;
+  }
+  .stage + .arrow {
+    align-self: center;
+    color: var(--faint);
+    padding: 0 6px;
+    font-size: 15px;
+    flex: 0 0 auto;
+  }
+  .stage b {
+    display: block;
+    font-size: 14px;
+    color: var(--accent);
+    margin-bottom: 3px;
+  }
+  .stage span { font-size: 12.5px; color: var(--muted); display: block; line-height: 1.45; }
+  .loop-return {
+    font-size: 13px;
+    color: var(--muted);
+    margin: 10px 0 0;
+    padding-left: 4px;
+  }
+  .loop-return code { font-size: 12px; }
+
+  /* ── Rules ── */
+  .rule {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-soft);
+    border-radius: 0 8px 8px 0;
+    padding: 14px 18px;
+    margin: 18px 0;
+    max-width: 44em;
+  }
+  .rule b { display: block; margin-bottom: 4px; }
+  .rule p { margin: 0; color: var(--muted); font-size: 15px; }
+  .rule p strong { color: var(--ink); }
+
+  /* ── Tables ── */
+  .table-wrap { overflow-x: auto; margin: 20px 0; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 14.5px;
+    min-width: 560px;
+  }
+  th {
+    text-align: left;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--faint);
+    font-weight: 600;
+    padding: 8px 14px 8px 0;
+    border-bottom: 2px solid var(--line);
+  }
+  td {
+    padding: 10px 14px 10px 0;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+    font-variant-numeric: tabular-nums;
+  }
+  td.k { white-space: nowrap; font-weight: 600; }
+  td .dim { color: var(--muted); }
+
+  .drop { color: var(--faint); text-decoration: line-through; }
+  .tag {
+    display: inline-block;
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    border-radius: 20px;
+    padding: 2px 10px;
+    vertical-align: 1px;
+  }
+  .tag.cut { background: var(--gate-soft); color: var(--gate); }
+  .tag.keep { background: var(--accent-soft); color: var(--accent); }
+
+  /* ── Phases ── */
+  .phase {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    margin: 22px 0;
+    overflow: hidden;
+  }
+  .phase-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 14px 20px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--line);
+    flex-wrap: wrap;
+  }
+  .phase-num {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent);
+    font-weight: 600;
+    flex: 0 0 auto;
+  }
+  .phase-head h3 { margin: 0; font-size: 16.5px; flex: 1 1 auto; }
+  .phase-size {
+    font-size: 12px;
+    color: var(--faint);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .phase-body { padding: 6px 20px 18px; }
+  .phase-body ul { margin: 10px 0; }
+  .files {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 14px;
+  }
+  .files code {
+    font-size: 12px;
+    color: var(--muted);
+    background: var(--code-bg);
+    border: 1px solid var(--line);
+    padding: 2px 8px;
+    border-radius: 20px;
+  }
+  .verify-note {
+    font-size: 13.5px;
+    color: var(--muted);
+    border-top: 1px dashed var(--line);
+    margin-top: 14px;
+    padding-top: 10px;
+  }
+  .verify-note b { color: var(--pass); font-weight: 600; }
+
+  /* ── Ladder gate illustration ── */
+  .rungs { display: flex; gap: 8px; margin: 22px 0 6px; flex-wrap: wrap; }
+  .rung {
+    flex: 1 1 110px;
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    padding: 10px 12px;
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  .rung b { display: block; font-size: 13px; }
+  .rung .st { display: block; font-weight: 600; }
+  .rung.passed { background: var(--accent-soft); border-color: transparent; }
+  .rung.passed .st { color: var(--pass); }
+  .rung.open .st { color: var(--accent); }
+  .rung.locked { background: var(--panel); color: var(--faint); }
+  .rung.locked b { color: var(--faint); }
+  .rung.locked .st { color: var(--gate); }
+  .rung .req { color: var(--faint); font-variant-numeric: tabular-nums; }
+  figcaption { font-size: 13px; color: var(--faint); margin-top: 6px; }
+  figure { margin: 0; }
+
+  /* ── Decisions ledger ── */
+  .ledger { border-top: 2px solid var(--line); margin-top: 16px; }
+  .ledger-row {
+    display: grid;
+    grid-template-columns: minmax(140px, 200px) 1fr;
+    gap: 16px;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line);
+    font-size: 14.5px;
+  }
+  .ledger-row dt { font-weight: 600; margin: 0; }
+  .ledger-row dd { margin: 0; color: var(--muted); }
+  .ledger-row dd strong { color: var(--ink); }
+  @media (max-width: 540px) {
+    .ledger-row { grid-template-columns: 1fr; gap: 2px; }
+    h1 { font-size: 32px; }
+  }
+
+  footer {
+    margin-top: 72px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-size: 13px;
+    color: var(--faint);
+  }
+</style>
+
+<div class="page">
+  <header class="doc">
+    <p class="eyebrow">SpeechPractice · planning doc · July 8, 2026</p>
+    <h1>The core loop</h1>
+    <p class="thesis">SpeechPractice is <strong>an objective, closed-loop trainer for scripted-speech clarity</strong>: it measures how intelligibly you read, finds your specific weak spots, writes you material dense in exactly those targets, and proves — with the same deterministic ruler — that you fixed them.</p>
+  </header>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">1</span>What it is, what it isn't</h2>
+  <p class="lede">The gen-1 core (read → transcribe → align → score → highlight) is a <em>measurement instrument</em>. Everything we're adding is a <em>coaching loop wrapped around that instrument</em> — and every new feature must be justifiable as a step in that loop.</p>
+  <ul>
+    <li><strong>The ruler is machine intelligibility.</strong> Clarity = 1 − flexible WER against Whisper. That's a proxy for human intelligibility — imperfect, but objective and comparable across months. The self-review flow is the human override for when the proxy mishears.</li>
+    <li><strong>Not</strong> a phoneme-level pronunciation tutor (ASR can't see formants), <strong>not</strong> a content or delivery coach. Free Speak stays a fluency dipstick — pace, pauses, fillers — with no accuracy pretense.</li>
+  </ul>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">2</span>The loop</h2>
+  <p class="lede">Five stages, each with exactly one job. The looseness in the current app is that stages 3→4→5 don't connect: practicing a drill doesn't reliably credit its card, and nothing ever proves a card fixed.</p>
+
+  <div class="loop-wrap">
+    <div class="loop">
+      <div class="stage"><b>Measure</b><span>Reading sessions produce immutable evidence: scores + per-token error events.</span></div>
+      <div class="arrow">→</div>
+      <div class="stage"><b>Diagnose</b><span>Analytics <em>proposes</em> cards; self-review confirms or adds. A card = a hypothesis with evidence.</span></div>
+      <div class="arrow">→</div>
+      <div class="stage"><b>Treat</b><span>AI writes drills &amp; ladders dense in the card's targets. Ladders are the canonical treatment.</span></div>
+      <div class="arrow">→</div>
+      <div class="stage"><b>Verify</b><span>Re-measure on treatment material. Each card graded on <em>its own target's</em> performance.</span></div>
+      <div class="arrow">→</div>
+      <div class="stage"><b>Retire &amp; watch</b><span>Mastered cards leave the queue; analytics keeps sentinel duty on the target.</span></div>
+    </div>
+  </div>
+  <p class="loop-return">↩ <strong>Lapse path:</strong> a retired target that re-errors in ordinary reading sessions re-enters at Diagnose — the card comes back with fresh evidence, not from scratch.</p>
+
+  <h3>The two rules that keep it coherent</h3>
+  <div class="rule">
+    <b>Rule A — Cards are entities, not views.</b>
+    <p>Analytics <strong>proposes new cards and refreshes evidence</strong> (stats, prompt, title). Reviews <strong>progress</strong> them (mastery, status, due date). Analytics never writes SRS state on an existing card. Today <code>refresh_improvement_cards</code> clobbers mastery after every session — this is the first thing we fix.</p>
+  </div>
+  <div class="rule">
+    <b>Rule B — AI generates, deterministic code grades.</b>
+    <p>LLMs write drill text and translate self-review notes into cards. Scoring, per-target grading, mastery, and rung gates stay pure alignment math, so <strong>a 92% clarity in March means the same as a 92% in July</strong>. No model ever assigns mastery or passes a rung.</p>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">3</span>Verify: per-target grading is the core, not phase 2</h2>
+  <p class="lede">Today every linked card gets the same session-global quality (65% score + 35% WER). That smears one number across all cards and makes mastery mean "you read well lately," not "you fixed this." Instead, each card kind gets an <strong>evidence extractor</strong> that answers, for one session: how many chances did this target get, and how many did it miss?</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Card kind</th><th>Opportunities (per session)</th><th>Misses</th><th>Source</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="k">word</td>
+          <td>Occurrences of the target word in the cleaned script text</td>
+          <td><code>SessionError</code> rows with <code>ref_token == target</code>, op <code>sub</code>/<code>del</code></td>
+          <td class="dim">already stored</td>
+        </tr>
+        <tr>
+          <td class="k">sound</td>
+          <td>Symbol count via <code>_word_to_phoneme_symbols</code> over script words</td>
+          <td>Confusion pairs from sub/del events, keyed by ref symbol</td>
+          <td class="dim"><code>_phoneme_stats</code>, run per-session</td>
+        </tr>
+        <tr>
+          <td class="k">character</td>
+          <td>Occurrences of the character in cleaned script</td>
+          <td><code>char_replace</code> / char-kind error events matching target</td>
+          <td class="dim">already stored</td>
+        </tr>
+        <tr>
+          <td class="k">position</td>
+          <td>Tokens contributing to the bucket (start / middle / end)</td>
+          <td>Error events whose local position maps to the bucket</td>
+          <td class="dim">position trend logic, per-session</td>
+        </tr>
+        <tr>
+          <td class="k">fluency</td>
+          <td colspan="2">Always has evidence: graded from <code>artic_rate</code>, <code>pause_ratio</code>, <code>filled_pauses</code> against the metric-target bands</td>
+          <td class="dim">session metrics</td>
+        </tr>
+        <tr>
+          <td class="k drop">phrase</td>
+          <td colspan="3"><span class="tag cut">removed</span> <span class="dim">— mostly one-off n-grams, no reusable training value; see §4</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>The quality formula</h3>
+  <p>Target evidence is blended with session quality using a shrinkage weight, so two occurrences of a word don't swing mastery as hard as ten:</p>
+  <pre><code>target_quality  = 1 − (misses / opportunities)
+w               = opportunities / (opportunities + 3)     # trust grows with evidence
+quality         = w · target_quality + (1 − w) · session_quality
+
+# session_quality stays the existing blend: 65% scaled score + 35% (1 − WER)
+# opportunities == 0  →  no review for that card (no evidence, no credit)
+# fluency cards       →  always graded, from the session's fluency metrics</code></pre>
+  <p>The "no evidence, no credit" rule matters: a ladder level that happens to omit a target simply doesn't touch that card, instead of granting it free mastery. Generated ladders weave every target into every level, so in practice all ladder cards get graded on every rung.</p>
+
+  <h3>Which cards a session updates (fan-out)</h3>
+  <p>When a scoring job succeeds, the set of candidate cards is the union of:</p>
+  <ul>
+    <li>the <strong>explicit card</strong> on the job (quick-practice form selection),</li>
+    <li>if the script is a ladder step: <strong>all cards on the ladder's</strong> <code>cards</code> <strong>M2M</strong> (focus lists are effectively ladder-wide by design — every level weaves every target),</li>
+    <li><strong>all</strong> <code>GeneratedPracticeScript</code> links for the script — not the current arbitrary <code>.first()</code>.</li>
+  </ul>
+  <p>Dedupe, then run one evidence-graded review per card. <code>PracticeReview</code> records the per-card quality plus its evidence (opportunities, misses) so the card's history is auditable.</p>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">4</span>Card cleanup: drop phrase cards</h2>
+  <p class="lede">Phrase cards are one-off n-grams from a single bad take — they don't name a reusable skill, they bloat the queue, and there's no honest per-session evidence extractor for them (the exact phrase rarely reappears in new material).</p>
+  <ul>
+    <li>Remove the phrase block from <code>build_card_candidates</code> — trends stop proposing them.</li>
+    <li>Remove <code>phrase</code> from the self-review card prompt's kind list (a phrase-shaped complaint becomes a <code>word</code>, <code>sound</code>, or <code>fluency</code> card instead).</li>
+    <li>Data migration pauses existing phrase cards rather than deleting — history and reviews stay intact, they just leave the queue and ladder-generation pickers.</li>
+    <li>The model choice constant stays (old rows reference it); it's just no longer produced.</li>
+  </ul>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">5</span>Ladder gates: mastery in context</h2>
+  <p class="lede">"Mastered" shouldn't mean your average went up — it means the target survived progressively harder contexts. The five ladder levels are exactly that difficulty gradient, so gating rungs on clarity is what makes Verify real.</p>
+
+  <figure>
+    <div class="rungs">
+      <div class="rung passed"><b>1 · Warm-up</b><span class="st">Passed · 94%</span><span class="req">needs ≥ 85%</span></div>
+      <div class="rung passed"><b>2 · Contrast</b><span class="st">Passed · 91%</span><span class="req">needs ≥ 88%</span></div>
+      <div class="rung open"><b>3 · Density</b><span class="st">Open · best 87%</span><span class="req">needs ≥ 90%</span></div>
+      <div class="rung locked"><b>4 · Flow</b><span class="st">Locked</span><span class="req">pass level 3 first</span></div>
+      <div class="rung locked"><b>5 · Performance</b><span class="st">Locked</span><span class="req">pass level 4 first</span></div>
+    </div>
+    <figcaption>How the ladder panel reads after this ships: pass state, best clarity, and the bar to clear are all visible per rung.</figcaption>
+  </figure>
+
+  <ul>
+    <li><strong>Rule:</strong> rung N+1 unlocks when rung N has a session with clarity ≥ its <code>min_clarity</code>. Level 1 is always open. (Clarity is 1 − flexible WER, so this is equivalently a WER ceiling.)</li>
+    <li><strong>Threshold:</strong> new <code>min_clarity</code> field on <code>PracticeLadderStep</code>. Generated ladders ramp <strong>85 → 88 → 90 → 92 → 95</strong> to match the warm-up → performance level design; plain default is 90 (the "good" clarity band).</li>
+    <li><strong>State:</strong> new <code>LadderStepProgress</code> model — <code>(user, step)</code> unique, with <code>best_clarity</code>, <code>attempts</code>, <code>passed_at</code>, <code>best_session_id</code>. Upserted when a scoring job for a ladder-step script succeeds.</li>
+    <li><strong>Enforcement in three places:</strong> GET for a locked level redirects to the highest unlocked rung with a message; POST rejects a locked rung's script (no URL-crafting around the gate); the template renders locked rungs disabled with the requirement stated.</li>
+    <li><strong>Backfill:</strong> management command walks succeeded <code>ScoringJob</code>s for ladder-step scripts → <code>legacy_session_id</code> → session clarity, and builds progress rows — existing users keep their earned unlocks.</li>
+    <li><strong>Unlock moment:</strong> the job-status payload (already polled) carries a "Level 4 unlocked" event for the results page.</li>
+  </ul>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">6</span>Implementation plan</h2>
+  <p class="lede">Ordered so each phase is independently shippable and each one strictly tightens the loop. Nothing here blocks on new schema until phase 2.</p>
+
+  <div class="phase">
+    <div class="phase-head">
+      <span class="phase-num">Phase 0</span>
+      <h3>Stop the clobber · retire phrase cards</h3>
+      <span class="phase-size">small</span>
+    </div>
+    <div class="phase-body">
+      <ul>
+        <li><code>refresh_improvement_cards</code>: on <em>existing</em> cards, update only <code>stats</code>/<code>title</code>/<code>prompt</code>; write <code>mastery</code>/<code>status</code>/<code>due_at</code> only on create. Guard: if <code>last_reviewed_at</code> is set, SRS fields are untouchable by analytics. <em>(Rule A, and the prerequisite for everything below — reviews currently get erased seconds after they happen.)</em></li>
+        <li>Remove phrase candidates from trends and the self-review prompt; migration pauses existing phrase cards.</li>
+      </ul>
+      <div class="files"><code>practice/services/analytics.py</code><code>practice/services/script_generation.py</code><code>practice/migrations/</code></div>
+      <p class="verify-note"><b>Proof:</b> test — review a card, run refresh, mastery/status/due unchanged; new trend card still created with seeded mastery; no phrase candidates emitted.</p>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-head">
+      <span class="phase-num">Phase 1</span>
+      <h3>Evidence-graded fan-out</h3>
+      <span class="phase-size">medium-large</span>
+    </div>
+    <div class="phase-body">
+      <ul>
+        <li>New <code>practice/services/evidence.py</code>: per-kind extractors returning <code>(opportunities, misses)</code> for one session, reusing the alignment/phoneme logic already in <code>error_analytics.py</code>; the shrinkage quality blend lives here.</li>
+        <li><code>spaced_repetition.py</code>: <code>update_card_from_session</code> takes the per-card quality; review notes + <code>card.stats.last_review</code> record the evidence.</li>
+        <li><code>jobs.py</code>: card resolver = explicit job card ∪ ladder M2M (via <code>script.ladder_steps</code>) ∪ <em>all</em> <code>GeneratedPracticeScript</code> links, deduped; one review per card with evidence.</li>
+      </ul>
+      <div class="files"><code>practice/services/evidence.py</code> <code>practice/services/spaced_repetition.py</code><code>practice/services/jobs.py</code></div>
+      <p class="verify-note"><b>Proof:</b> tests — word card credited only when its word appears; a missed target lowers that card but not siblings; ladder session reviews every ladder card; the arbitrary-<code>.first()</code> behavior is gone. Then one real ladder take end-to-end.</p>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-head">
+      <span class="phase-num">Phase 2</span>
+      <h3>Gated rungs + backfill</h3>
+      <span class="phase-size">medium</span>
+    </div>
+    <div class="phase-body">
+      <ul>
+        <li>Migration: <code>PracticeLadderStep.min_clarity</code> (default 0.90; generation writes the 85→95 ramp) + <code>LadderStepProgress</code>.</li>
+        <li><code>jobs.py</code>: upsert progress on success; surface newly-passed in the job payload.</li>
+        <li><code>views.py</code>: unlocked-level computation, GET redirect, POST guard; template lock/pass states per the mock in §5.</li>
+        <li><code>backfill_ladder_progress</code> management command.</li>
+      </ul>
+      <div class="files"><code>practice/models.py</code><code>practice/services/jobs.py</code><code>practice/views.py</code><code>templates/practice/practice_run.html</code><code>practice/management/commands/</code></div>
+      <p class="verify-note"><b>Proof:</b> tests — locked GET redirects, locked POST rejected, pass unlocks next rung, backfill reproduces unlocks from historical jobs; then run the backfill on the real local DB and eyeball the ladder panel.</p>
+    </div>
+  </div>
+
+  <div class="phase">
+    <div class="phase-head">
+      <span class="phase-num">Phase 3</span>
+      <h3>Card story page (make the loop felt)</h3>
+      <span class="phase-size">later</span>
+    </div>
+    <div class="phase-body">
+      <ul>
+        <li>A card detail view that narrates the flywheel: <em>spotted in these sessions → drilled in these ladders → target error rate fell 40% → 8% → mastered June 30</em>. All the data exists after phases 0–2; this is the UI that stops the app feeling like disconnected features.</li>
+        <li>Mastery curve from <code>PracticeReview</code> rows; evidence timeline from the recorded per-session opportunities/misses.</li>
+      </ul>
+      <div class="files"><code>practice/views.py</code><code>templates/practice/</code><code>static/practice/</code></div>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <h2><span class="sec">7</span>Decisions ledger</h2>
+  <p class="lede">What we've settled in discussion, so the build doesn't relitigate it.</p>
+  <dl class="ledger">
+    <div class="ledger-row"><dt>Ladder fan-out</dt><dd>All cards on the ladder's M2M — focus lists are ladder-wide in practice (every level weaves every target by design), so no focus-matching.</dd></div>
+    <div class="ledger-row"><dt>Gate metric</dt><dd>Clarity only (= 1 − flexible WER). No separate WER ceiling — it's the same number.</dd></div>
+    <div class="ledger-row"><dt>Per-target grading</dt><dd><strong>In the core loop from the start</strong> (phase 1), not deferred. No evidence → no credit.</dd></div>
+    <div class="ledger-row"><dt>Phrase cards</dt><dd>Removed from generation; existing ones paused, history kept.</dd></div>
+    <div class="ledger-row"><dt>Backfill</dt><dd>Yes — historical sessions count toward rung unlocks.</dd></div>
+    <div class="ledger-row"><dt>Clobber fix</dt><dd>Prerequisite, ships first (phase 0).</dd></div>
+    <div class="ledger-row"><dt>AI's role</dt><dd>Generates material and translates self-review notes. Never grades, never assigns mastery, never passes a rung.</dd></div>
+  </dl>
+
+  <h3>Still open (small)</h3>
+  <ul>
+    <li>Builtin/imported ladders with no linked cards: gates work (progress is per-step), card updates are simply a no-op. Acceptable, or should imported ladders get a card-linking step?</li>
+    <li>Shrinkage constant (k = 3) and the 85→95 ramp are starting values — tune after a week of real use.</li>
+    <li>Does a <em>failed</em> gate attempt still schedule the card (quality &lt; 0.5 → due tomorrow)? Current SRS says yes; feels right, flagging it as intended behavior.</li>
+  </ul>
+
+  <footer>SpeechPractice · core loop &amp; implementation plan · drafted with Claude Code, July 8, 2026</footer>
+</div>

--- a/practice/management/commands/backfill_ladder_progress.py
+++ b/practice/management/commands/backfill_ladder_progress.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+
+from practice.models import LadderStepProgress, PracticeSession, ScoringJob
+from practice.services.jobs import upsert_ladder_step_progress
+
+
+class Command(BaseCommand):
+    help = "Rebuild ladder step progress from historical succeeded scoring jobs."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--user", dest="username", help="Only backfill jobs for this username.")
+
+    def handle(self, *args, **options):
+        username = options.get("username")
+        jobs = (
+            ScoringJob.objects.select_related("user", "script")
+            .filter(
+                status=ScoringJob.STATUS_SUCCEEDED,
+                mode=ScoringJob.MODE_SCORE,
+                legacy_session_id__isnull=False,
+                script__isnull=False,
+                script__ladder_steps__isnull=False,
+            )
+            .distinct()
+        )
+        if username:
+            jobs = jobs.filter(user__username=username)
+
+        entries = []
+        affected_by_user: dict[int, set[int]] = defaultdict(set)
+        for job in jobs:
+            session = PracticeSession.objects.filter(user=job.user, pk=job.legacy_session_id).first()
+            if session is None:
+                continue
+            steps = list(job.script.ladder_steps.select_related("ladder").order_by("ladder_id", "level"))
+            if not steps:
+                continue
+            event_time = job.finished_at or job.created_at
+            entries.append((event_time, job.pk, job, session, steps))
+            for step in steps:
+                affected_by_user[job.user_id].add(step.pk)
+
+        for user_id, step_ids in affected_by_user.items():
+            LadderStepProgress.objects.filter(user_id=user_id, step_id__in=step_ids).delete()
+
+        created_count = 0
+        pass_count = 0
+        for event_time, _job_pk, job, session, steps in sorted(entries, key=lambda item: (item[0], item[1])):
+            for step in steps:
+                _progress, created, passed = upsert_ladder_step_progress(
+                    user=job.user,
+                    step=step,
+                    session=session,
+                    event_time=event_time,
+                )
+                created_count += int(created)
+                pass_count += int(passed)
+
+        self.stdout.write(f"Backfilled ladder progress: rows created {created_count}, passes {pass_count}.")

--- a/practice/migrations/0015_pause_phrase_improvement_cards.py
+++ b/practice/migrations/0015_pause_phrase_improvement_cards.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def pause_phrase_cards(apps, schema_editor):
+    ImprovementCard = apps.get_model("practice", "ImprovementCard")
+    ImprovementCard.objects.filter(kind="phrase").exclude(status="paused").update(status="paused")
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("practice", "0014_alter_generatedpracticescript_user_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(pause_phrase_cards, noop_reverse),
+    ]

--- a/practice/migrations/0016_ladder_step_progress.py
+++ b/practice/migrations/0016_ladder_step_progress.py
@@ -1,0 +1,79 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+
+
+def backfill_min_clarity(apps, schema_editor):
+    PracticeLadderStep = apps.get_model("practice", "PracticeLadderStep")
+    # Keep this ramp in sync with practice.views.LADDER_MIN_CLARITY_BY_LEVEL.
+    ramp = {
+        1: 0.85,
+        2: 0.88,
+        3: 0.90,
+        4: 0.92,
+        5: 0.95,
+    }
+    for level, min_clarity in ramp.items():
+        PracticeLadderStep.objects.filter(level=level).update(min_clarity=min_clarity)
+    PracticeLadderStep.objects.filter(level__gt=5).update(min_clarity=0.95)
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("practice", "0015_pause_phrase_improvement_cards"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="practiceladderstep",
+            name="min_clarity",
+            field=models.FloatField(default=0.9),
+        ),
+        migrations.CreateModel(
+            name="LadderStepProgress",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("best_clarity", models.FloatField(default=0.0)),
+                ("attempts", models.PositiveIntegerField(default=0)),
+                ("passed_at", models.DateTimeField(blank=True, null=True)),
+                ("best_session_id", models.IntegerField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "step",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="progress",
+                        to="practice.practiceladderstep",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="ladder_step_progress",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="ladderstepprogress",
+            constraint=models.UniqueConstraint(
+                fields=("user", "step"),
+                name="unique_user_ladder_step_progress",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="ladderstepprogress",
+            index=models.Index(fields=["user", "step"], name="practice_la_user_id_fdbc10_idx"),
+        ),
+        migrations.RunPython(backfill_min_clarity, noop_reverse),
+    ]

--- a/practice/migrations/0017_practicereview_story_data.py
+++ b/practice/migrations/0017_practicereview_story_data.py
@@ -1,0 +1,62 @@
+import re
+
+from django.db import migrations, models
+
+# Inlined copy of practice.services.review_notes.parse_legacy_review_notes so this
+# migration never depends on app code that may move or change.
+_LEGACY_REVIEW_NOTES_RE = re.compile(
+    r"Quality (\d+(?:\.\d+)?); mastery (\d+(?:\.\d+)?) -> (\d+(?:\.\d+)?)"
+)
+
+
+def parse_legacy_review_notes(notes):
+    match = _LEGACY_REVIEW_NOTES_RE.search(notes or "")
+    if not match:
+        return None
+    return float(match.group(1)), float(match.group(3))
+
+
+def backfill_review_story_data(apps, schema_editor):
+    PracticeReview = apps.get_model("practice", "PracticeReview")
+    pending = []
+    for review in PracticeReview.objects.exclude(notes="").iterator(chunk_size=500):
+        parsed = parse_legacy_review_notes(review.notes)
+        if parsed is None:
+            continue
+        review.quality, review.mastery_after = parsed
+        pending.append(review)
+        if len(pending) >= 500:
+            PracticeReview.objects.bulk_update(pending, ["quality", "mastery_after"])
+            pending = []
+    if pending:
+        PracticeReview.objects.bulk_update(pending, ["quality", "mastery_after"])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("practice", "0016_ladder_step_progress"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="practicereview",
+            name="quality",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="practicereview",
+            name="mastery_after",
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="practicereview",
+            name="evidence",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.RunPython(backfill_review_story_data, noop_reverse),
+    ]

--- a/practice/models.py
+++ b/practice/models.py
@@ -235,6 +235,9 @@ class PracticeReview(models.Model):
     legacy_session_id = models.IntegerField(blank=True, null=True)
     score = models.FloatField(blank=True, null=True)
     error_rate = models.FloatField(blank=True, null=True)
+    quality = models.FloatField(blank=True, null=True)
+    mastery_after = models.FloatField(blank=True, null=True)
+    evidence = models.JSONField(blank=True, null=True)
     notes = models.TextField(blank=True)
     reviewed_at = models.DateTimeField(default=timezone.now)
 

--- a/practice/models.py
+++ b/practice/models.py
@@ -393,6 +393,7 @@ class PracticeLadderStep(models.Model):
     level = models.PositiveSmallIntegerField()
     title = models.CharField(max_length=255)
     focus = models.JSONField(default=list, blank=True)
+    min_clarity = models.FloatField(default=0.90)
     created_at = models.DateTimeField(default=timezone.now)
 
     class Meta:
@@ -406,6 +407,36 @@ class PracticeLadderStep(models.Model):
 
     def __str__(self) -> str:
         return f"{self.ladder}: level {self.level}"
+
+
+class LadderStepProgress(models.Model):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="ladder_step_progress",
+    )
+    step = models.ForeignKey(
+        PracticeLadderStep,
+        on_delete=models.CASCADE,
+        related_name="progress",
+    )
+    best_clarity = models.FloatField(default=0.0)
+    attempts = models.PositiveIntegerField(default=0)
+    passed_at = models.DateTimeField(blank=True, null=True)
+    best_session_id = models.IntegerField(blank=True, null=True)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["user", "step"], name="unique_user_ladder_step_progress"),
+        ]
+        indexes = [
+            models.Index(fields=["user", "step"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.user}: {self.step}"
 
 
 _FERNET = None

--- a/practice/services/analytics.py
+++ b/practice/services/analytics.py
@@ -531,25 +531,6 @@ def build_card_candidates(summary: dict[str, Any]) -> list[dict[str, Any]]:
             }
         )
 
-    for row in summary.get("phrases", {}).get("top_trouble_phrases", [])[:5]:
-        phrase = row.get("phrase")
-        if not phrase:
-            continue
-        rate = float(row.get("error_rate", 0.0))
-        candidates.append(
-            {
-                "kind": ImprovementCard.KIND_PHRASE,
-                "target_key": str(phrase),
-                "title": str(phrase),
-                "prompt": (
-                    "Practice this phrase in isolation, then inside short surrounding "
-                    "sentences while keeping pace and articulation steady."
-                ),
-                "stats": row,
-                "mastery": _mastery_from_error_rate(rate),
-            }
-        )
-
     for row in summary.get("positions", {}).get("top_position_buckets", [])[:4]:
         bucket = row.get("bucket")
         if not bucket:
@@ -603,19 +584,26 @@ def refresh_improvement_cards(
         stats = dict(candidate["stats"])
         stats.update(source_window)
         stats["source_window_refreshed_at"] = refreshed_at.isoformat()
-        _card, created = ImprovementCard.objects.update_or_create(
+        defaults = {
+            "title": candidate["title"],
+            "prompt": candidate["prompt"],
+            "stats": stats,
+            "mastery": mastery,
+            "status": status,
+            "due_at": _due_date_for_mastery(mastery),
+        }
+        card, created = ImprovementCard.objects.get_or_create(
             user=user,
             kind=candidate["kind"],
             target_key=candidate["target_key"],
-            defaults={
-                "title": candidate["title"],
-                "prompt": candidate["prompt"],
-                "stats": stats,
-                "mastery": mastery,
-                "status": status,
-                "due_at": _due_date_for_mastery(mastery),
-            },
+            defaults=defaults,
         )
+        if not created:
+            ImprovementCard.objects.filter(user=user, pk=card.pk).update(
+                title=candidate["title"],
+                prompt=candidate["prompt"],
+                stats=stats,
+            )
         count += 1 if created else 0
     return count
 

--- a/practice/services/evidence.py
+++ b/practice/services/evidence.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from error_analytics import (
+    _phoneme_stats,
+    _position_bucket,
+    _position_stats,
+    clean_text_for_alignment,
+)
+
+from practice.models import ImprovementCard, PracticeSession
+
+SHRINKAGE_K = 3
+
+ARTIC_RATE_IDEAL_MIN = 120.0
+ARTIC_RATE_IDEAL_MAX = 160.0
+ARTIC_RATE_DECAY = 40.0
+PAUSE_RATIO_IDEAL_MIN = 0.10
+PAUSE_RATIO_IDEAL_MAX = 0.25
+PAUSE_RATIO_DECAY = 0.15
+FILLED_PAUSES_DECAY = 6.0
+
+
+def session_quality(session: PracticeSession) -> float:
+    score = float(session.score or 0.0)
+    wer = float(session.wer or 1.0)
+    score_quality = max(0.0, min(1.0, (score - 1.0) / 4.0))
+    wer_quality = max(0.0, min(1.0, 1.0 - wer))
+    return round((score_quality * 0.65) + (wer_quality * 0.35), 3)
+
+
+def card_evidence(card: ImprovementCard, session: PracticeSession, events: Sequence) -> dict | None:
+    if card.kind == ImprovementCard.KIND_WORD:
+        return _word_evidence(card.target_key, session, events)
+    if card.kind == ImprovementCard.KIND_SOUND:
+        return _sound_evidence(card.target_key, session, events)
+    if card.kind == ImprovementCard.KIND_CHARACTER:
+        return _character_evidence(card.target_key, session, events)
+    if card.kind == ImprovementCard.KIND_POSITION:
+        return _position_evidence(card.target_key, session, events)
+    return None
+
+
+def quality_for_card(
+    card: ImprovementCard,
+    session: PracticeSession,
+    events: Sequence,
+) -> float | None:
+    quality, _evidence = quality_and_evidence_for_card(card, session, events)
+    return quality
+
+
+def quality_and_evidence_for_card(
+    card: ImprovementCard,
+    session: PracticeSession,
+    events: Sequence,
+) -> tuple[float | None, dict | None]:
+    if card.kind == ImprovementCard.KIND_FLUENCY:
+        return _fluency_quality(session), None
+    if card.kind == ImprovementCard.KIND_PHRASE:
+        return None, None
+
+    evidence = card_evidence(card, session, events)
+    if evidence is None or int(evidence.get("opportunities", 0)) <= 0:
+        return None, evidence
+
+    opportunities = int(evidence["opportunities"])
+    misses = int(evidence.get("misses", 0))
+    target_quality = 1.0 - (float(misses) / float(opportunities))
+    target_quality = max(0.0, min(1.0, target_quality))
+    w = float(opportunities) / float(opportunities + SHRINKAGE_K)
+    quality = (w * target_quality) + ((1.0 - w) * session_quality(session))
+    return round(quality, 3), evidence
+
+
+def _word_evidence(target_key: str, session: PracticeSession, events: Sequence) -> dict:
+    target = clean_text_for_alignment(target_key).strip()
+    tokens = clean_text_for_alignment(session.script_text).split()
+    opportunities = sum(1 for token in tokens if token == target)
+    misses = 0
+    for row in events:
+        if row.op not in {"sub", "del"}:
+            continue
+        if clean_text_for_alignment(row.ref_token or "").strip() == target:
+            misses += 1
+    return {"opportunities": opportunities, "misses": misses}
+
+
+def _sound_evidence(target_key: str, session: PracticeSession, events: Sequence) -> dict:
+    target = str(target_key or "").strip().upper()
+    stats, _top_pairs = _phoneme_stats([session], events)
+    row = stats.get(target)
+    if not row:
+        return {"opportunities": 0, "misses": 0}
+    return {
+        "opportunities": int(row.get("attempts", 0)),
+        "misses": int(row.get("errors", 0)),
+    }
+
+
+def _character_evidence(target_key: str, session: PracticeSession, events: Sequence) -> dict:
+    target = clean_text_for_alignment(target_key).replace(" ", "")
+    target = target[:1]
+    text = clean_text_for_alignment(session.script_text).replace(" ", "")
+    opportunities = sum(1 for ch in text if ch == target) if target else 0
+
+    misses = 0
+    for row in events:
+        if not str(row.error_kind or "").startswith("char_"):
+            continue
+        ref_token = clean_text_for_alignment(row.ref_token or "").replace(" ", "")
+        if not ref_token or not target:
+            continue
+        start = int(row.ref_local_start) if row.ref_local_start is not None else 0
+        end = int(row.ref_local_end) if row.ref_local_end is not None else len(ref_token)
+        start = max(0, min(start, len(ref_token)))
+        end = max(start, min(end, len(ref_token)))
+        ref_chunk = ref_token[start:end] or ref_token
+        if target in ref_chunk:
+            misses += 1
+    return {"opportunities": opportunities, "misses": misses}
+
+
+def _position_evidence(target_key: str, session: PracticeSession, events: Sequence) -> dict:
+    target = str(target_key or "").strip().lower()
+    stats = _position_stats([session], events)
+    row = stats.get(target)
+    if not row:
+        return {"opportunities": 0, "misses": 0}
+
+    # Keep miss attribution tied to the same helper used by position trends.
+    misses = 0
+    for event in events:
+        if event.op not in ("sub", "del"):
+            continue
+        bucket = _position_bucket(event.ref_local_start, event.ref_local_end, event.ref_token_len)
+        if bucket == target:
+            misses += 1
+    return {
+        "opportunities": int(row.get("attempts", 0)),
+        "misses": misses,
+    }
+
+
+def _fluency_quality(session: PracticeSession) -> float:
+    components = []
+    if session.artic_rate is not None:
+        components.append(
+            _band_quality(
+                float(session.artic_rate),
+                ARTIC_RATE_IDEAL_MIN,
+                ARTIC_RATE_IDEAL_MAX,
+                ARTIC_RATE_DECAY,
+            )
+        )
+    if session.pause_ratio is not None:
+        components.append(
+            _band_quality(
+                float(session.pause_ratio),
+                PAUSE_RATIO_IDEAL_MIN,
+                PAUSE_RATIO_IDEAL_MAX,
+                PAUSE_RATIO_DECAY,
+            )
+        )
+    if session.filled_pauses is not None:
+        filled_quality = 1.0 - min(1.0, max(0.0, float(session.filled_pauses)) / FILLED_PAUSES_DECAY)
+        components.append(filled_quality)
+    if not components:
+        return session_quality(session)
+    return round(sum(components) / len(components), 3)
+
+
+def _band_quality(value: float, low: float, high: float, decay: float) -> float:
+    if low <= value <= high:
+        return 1.0
+    distance = low - value if value < low else value - high
+    return max(0.0, 1.0 - min(1.0, distance / decay))

--- a/practice/services/jobs.py
+++ b/practice/services/jobs.py
@@ -13,7 +13,10 @@ from django.utils import timezone
 from practice.models import (
     GeneratedPracticeScript,
     ImprovementCard,
+    LadderStepProgress,
+    PracticeSession,
     PracticeScript,
+    PracticeLadderStep,
     ScoringJob,
     SessionError,
     default_practice_user_pk,
@@ -142,6 +145,8 @@ def process_scoring_job(job_id: int) -> ScoringJob:
                         continue
                     update_card_from_session(card, session, quality=quality, evidence=evidence)
                 refresh_improvement_cards(user=job.user, days=settings.CARD_REFRESH_WINDOW_DAYS)
+                if job.script_id is not None:
+                    record_ladder_progress_for_session(user=job.user, script=job.script, session=session)
     except Exception as exc:
         job = ScoringJob.objects.get(pk=job_id)
         job.status = ScoringJob.STATUS_FAILED
@@ -178,6 +183,57 @@ def recover_stale_scoring_jobs(*, stale_after_minutes: int = 30) -> int:
         error_message="Recovered after the scoring worker stopped unexpectedly.",
         updated_at=timezone.now(),
     )
+
+
+def record_ladder_progress_for_session(
+    *,
+    user,
+    script: PracticeScript,
+    session: PracticeSession,
+    event_time=None,
+) -> tuple[int, int]:
+    created_count = 0
+    pass_count = 0
+    steps = script.ladder_steps.select_related("ladder").all()
+    for step in steps:
+        _progress, created, passed = upsert_ladder_step_progress(
+            user=user,
+            step=step,
+            session=session,
+            event_time=event_time,
+        )
+        created_count += int(created)
+        pass_count += int(passed)
+    return created_count, pass_count
+
+
+def upsert_ladder_step_progress(
+    *,
+    user,
+    step: PracticeLadderStep,
+    session: PracticeSession,
+    event_time=None,
+) -> tuple[LadderStepProgress, bool, bool]:
+    timestamp = event_time or timezone.now()
+    progress, created = LadderStepProgress.objects.get_or_create(
+        user=user,
+        step=step,
+        defaults={"created_at": timestamp},
+    )
+    was_passed = progress.passed_at is not None
+    progress.attempts = (progress.attempts or 0) + 1
+    if session.clarity is not None:
+        clarity = float(session.clarity)
+        if clarity > progress.best_clarity:
+            progress.best_clarity = clarity
+            progress.best_session_id = session.pk
+    if progress.passed_at is None and progress.best_clarity >= step.min_clarity:
+        progress.passed_at = timestamp
+    progress.save(update_fields=["attempts", "best_clarity", "best_session_id", "passed_at", "updated_at"])
+    if event_time is not None:
+        LadderStepProgress.objects.filter(pk=progress.pk).update(updated_at=timestamp)
+        progress.updated_at = timestamp
+    return progress, created, not was_passed and progress.passed_at is not None
 
 
 def _card_for_script(script: PracticeScript) -> ImprovementCard | None:

--- a/practice/services/jobs.py
+++ b/practice/services/jobs.py
@@ -10,9 +10,17 @@ from django.contrib.auth import get_user_model
 from django.db import close_old_connections, transaction
 from django.utils import timezone
 
-from practice.models import GeneratedPracticeScript, ImprovementCard, PracticeScript, ScoringJob, default_practice_user_pk
+from practice.models import (
+    GeneratedPracticeScript,
+    ImprovementCard,
+    PracticeScript,
+    ScoringJob,
+    SessionError,
+    default_practice_user_pk,
+)
 from practice.services.audio_storage import materialized_audio
 from practice.services.analytics import refresh_improvement_cards
+from practice.services.evidence import quality_and_evidence_for_card
 from practice.services.scoring import transcribe_free_and_store, transcribe_score_and_store
 from practice.services.spaced_repetition import update_card_from_session
 
@@ -127,7 +135,12 @@ def process_scoring_job(job_id: int) -> ScoringJob:
                     provider_name=job.provider,
                     partial_callback=on_partial,
                 )
-                update_card_from_session(job.card, session)
+                events = list(SessionError.objects.filter(user=job.user, session_id=session.pk))
+                for card in _candidate_cards_for_job(job):
+                    quality, evidence = quality_and_evidence_for_card(card, session, events)
+                    if quality is None:
+                        continue
+                    update_card_from_session(card, session, quality=quality, evidence=evidence)
                 refresh_improvement_cards(user=job.user, days=settings.CARD_REFRESH_WINDOW_DAYS)
     except Exception as exc:
         job = ScoringJob.objects.get(pk=job_id)
@@ -186,6 +199,38 @@ def _card_for_script(script: PracticeScript) -> ImprovementCard | None:
         except (ImprovementCard.DoesNotExist, ValueError):
             return None
     return None
+
+
+def _candidate_cards_for_job(job: ScoringJob) -> list[ImprovementCard]:
+    cards_by_id: dict[int, ImprovementCard] = {}
+
+    def add(card: ImprovementCard | None) -> None:
+        if card is None or card.pk is None:
+            return
+        if card.user_id != job.user_id:
+            return
+        if card.status == ImprovementCard.STATUS_PAUSED:
+            return
+        cards_by_id.setdefault(card.pk, card)
+
+    add(job.card)
+
+    if job.script_id is not None:
+        generated_records = GeneratedPracticeScript.objects.select_related("card").filter(
+            user=job.user,
+            script=job.script,
+            card__isnull=False,
+            card__user=job.user,
+        )
+        for generated in generated_records:
+            add(generated.card)
+
+        ladder_steps = job.script.ladder_steps.select_related("ladder").prefetch_related("ladder__cards")
+        for step in ladder_steps:
+            for card in step.ladder.cards.all():
+                add(card)
+
+    return list(cards_by_id.values())
 
 
 def job_status_context(job: ScoringJob) -> dict[str, Any]:

--- a/practice/services/review_notes.py
+++ b/practice/services/review_notes.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import re
+
+
+LEGACY_REVIEW_NOTES_RE = re.compile(
+    r"Quality (\d+(?:\.\d+)?); mastery (\d+(?:\.\d+)?) -> (\d+(?:\.\d+)?)"
+)
+
+
+def parse_legacy_review_notes(notes: str) -> tuple[float, float] | None:
+    match = LEGACY_REVIEW_NOTES_RE.search(notes or "")
+    if not match:
+        return None
+    return float(match.group(1)), float(match.group(3))

--- a/practice/services/script_generation.py
+++ b/practice/services/script_generation.py
@@ -269,7 +269,6 @@ def build_self_review_card_prompt(session: PracticeSession, notes: str) -> str:
         "Available card kinds:\n"
         "- word: a specific word to practice\n"
         "- sound: an articulation or sound pattern, including final consonants or swallowed endings\n"
-        "- phrase: a phrase the learner clipped, blurred, or rushed\n"
         "- position: a word-position issue such as final sounds or phrase endings\n"
         "- fluency: pace, pausing, rushing, breath, filler, or rhythm issues\n\n"
         f"Session: {session.script_name} at {session.timestamp}\n"
@@ -278,7 +277,7 @@ def build_self_review_card_prompt(session: PracticeSession, notes: str) -> str:
         "Return strict JSON only. Schema:\n"
         "{\n"
         '  "cards": [\n'
-        '    {"kind": "word|sound|phrase|position|fluency", "target": "short target key", '
+        '    {"kind": "word|sound|position|fluency", "target": "short target key", '
         '"title": "short display title", "prompt": "why and how to practice it"}\n'
         "  ]\n"
         "}\n"
@@ -789,7 +788,7 @@ def parse_self_review_cards(
             continue
         kind = _normalize_card_kind(row.get("kind"))
         target = _clean_target(row.get("target") or row.get("target_key") or row.get("focus"))
-        if not kind or not target:
+        if not kind or kind == ImprovementCard.KIND_PHRASE or not target:
             continue
         key = (kind, target.lower())
         if key in seen:
@@ -859,6 +858,8 @@ def _local_cards_from_self_review(
         if not chunk:
             continue
         kind = _kind_from_note(chunk)
+        if kind == ImprovementCard.KIND_PHRASE:
+            continue
         target = _target_from_note(chunk, kind)
         key = (kind, target.lower())
         if key in seen:

--- a/practice/services/spaced_repetition.py
+++ b/practice/services/spaced_repetition.py
@@ -5,24 +5,25 @@ from datetime import timedelta
 from django.utils import timezone
 
 from practice.models import ImprovementCard, PracticeReview, PracticeSession
+from practice.services.evidence import session_quality
 
 
 def quality_from_session(session: PracticeSession) -> float:
-    score = float(session.score or 0.0)
-    wer = float(session.wer or 1.0)
-    score_quality = max(0.0, min(1.0, (score - 1.0) / 4.0))
-    wer_quality = max(0.0, min(1.0, 1.0 - wer))
-    return round((score_quality * 0.65) + (wer_quality * 0.35), 3)
+    return session_quality(session)
 
 
 def update_card_from_session(
     card: ImprovementCard | None,
     session: PracticeSession,
+    *,
+    quality: float | None = None,
+    evidence: dict | None = None,
 ) -> PracticeReview | None:
     if card is None:
         return None
 
-    quality = quality_from_session(session)
+    if quality is None:
+        quality = quality_from_session(session)
     previous_mastery = float(card.mastery or 0.0)
     new_mastery = _next_mastery(previous_mastery, quality)
     card.mastery = new_mastery
@@ -36,6 +37,7 @@ def update_card_from_session(
             "score": float(session.score or 0.0),
             "wer": float(session.wer or 0.0),
             "quality": quality,
+            "evidence": evidence,
             "previous_mastery": previous_mastery,
             "mastery": new_mastery,
         },
@@ -55,12 +57,20 @@ def update_card_from_session(
         card=card,
         legacy_session_id=session.pk,
         score=session.score,
-        error_rate=session.wer,
+        error_rate=_error_rate(session, evidence),
         notes=(
             f"Auto review from scored session. Quality {quality:.2f}; "
             f"mastery {previous_mastery:.2f} -> {new_mastery:.2f}."
         ),
     )
+
+
+def _error_rate(session: PracticeSession, evidence: dict | None) -> float | None:
+    if evidence:
+        opportunities = int(evidence.get("opportunities", 0) or 0)
+        if opportunities > 0:
+            return float(evidence.get("misses", 0) or 0) / float(opportunities)
+    return session.wer
 
 
 def _next_mastery(previous: float, quality: float) -> float:

--- a/practice/services/spaced_repetition.py
+++ b/practice/services/spaced_repetition.py
@@ -58,6 +58,9 @@ def update_card_from_session(
         legacy_session_id=session.pk,
         score=session.score,
         error_rate=_error_rate(session, evidence),
+        quality=quality,
+        mastery_after=new_mastery,
+        evidence=evidence or None,
         notes=(
             f"Auto review from scored session. Quality {quality:.2f}; "
             f"mastery {previous_mastery:.2f} -> {new_mastery:.2f}."

--- a/practice/tests.py
+++ b/practice/tests.py
@@ -14,7 +14,7 @@ from django.core.management import call_command
 from django.db import connection
 from django.db.utils import OperationalError
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -34,7 +34,9 @@ from .models import (
 from .context_processors import static_version
 from .services.jobs import create_scoring_job, process_scoring_job
 from .services.evidence import quality_for_card, session_quality
+from .services.review_notes import parse_legacy_review_notes
 from .services.scoring import score_transcript
+from .services.spaced_repetition import update_card_from_session
 from .services.script_import import import_script_items, parse_csv_text, parse_json_text
 from .services.script_generation import (
     _stream_response_text,
@@ -47,6 +49,127 @@ from .services.script_generation import (
 from .services.codex_auth import serialize_token_bundle
 from .services.analytics import build_card_candidates, refresh_improvement_cards, today_queue
 from .services.transcription import OpenAITranscriptionProvider, TranscriptResult, UploadedTranscriptProvider
+from .views import _card_story
+
+
+class CardStoryTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="story-owner",
+            password="test-pass-story",
+        )
+        self.client.force_login(self.user)
+
+    def test_legacy_review_notes_parser_extracts_story_fields(self):
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: clear",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="clear",
+        )
+        review = PracticeReview.objects.create(
+            user=self.user,
+            card=card,
+            notes="Auto review from scored session. Quality 0.82; mastery 0.10 -> 0.35.",
+        )
+
+        parsed = parse_legacy_review_notes(review.notes)
+
+        self.assertEqual(parsed, (0.82, 0.35))
+
+    def test_update_card_from_session_populates_review_story_fields(self):
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: clear",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="clear",
+            mastery=0.1,
+        )
+        session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-09T10:00:00",
+            script_name="Clear Drill",
+            script_text="clear clear clear clear",
+            audio_path="",
+            transcript="clear clear clear",
+            score=4.0,
+            wer=0.15,
+        )
+
+        review = update_card_from_session(
+            card,
+            session,
+            quality=0.82,
+            evidence={"opportunities": 4, "misses": 1},
+        )
+
+        card.refresh_from_db()
+        self.assertIsNotNone(review)
+        self.assertEqual(review.quality, 0.82)
+        self.assertEqual(review.mastery_after, card.mastery)
+        self.assertEqual(review.evidence, {"opportunities": 4, "misses": 1})
+
+    def test_card_story_builds_mastery_curve_and_ordered_events(self):
+        base = timezone.now() - timedelta(days=4)
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: steady",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="steady",
+            mastery=0.8,
+            created_at=base,
+        )
+        for offset, mastery in enumerate((0.2, 0.5, 0.8), start=1):
+            PracticeReview.objects.create(
+                user=self.user,
+                card=card,
+                quality=0.8,
+                error_rate=0.1,
+                mastery_after=mastery,
+                reviewed_at=base + timedelta(days=offset),
+            )
+
+        story = _card_story(card)
+
+        points = story["mastery_curve"]["points"].split()
+        first_y = float(points[0].split(",")[1])
+        last_y = float(points[-1].split(",")[1])
+        self.assertEqual(len(points), 3)
+        self.assertEqual(first_y, 116.0)
+        self.assertEqual(last_y, 44.0)
+        self.assertLess(last_y, first_y)
+        self.assertEqual(story["story_events"][0]["kind"], "created")
+        self.assertEqual([event["at"] for event in story["story_events"]], sorted(event["at"] for event in story["story_events"]))
+        self.assertIn("review", {event["kind"] for event in story["story_events"]})
+
+    def test_card_story_without_reviews_has_created_event_and_no_curve(self):
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Sound pattern: R",
+            kind=ImprovementCard.KIND_SOUND,
+            target_key="R",
+        )
+
+        story = _card_story(card)
+
+        self.assertIsNone(story["mastery_curve"])
+        self.assertEqual(story["review_stats"]["count"], 0)
+        self.assertEqual([event["kind"] for event in story["story_events"]], ["created"])
+
+    def test_card_detail_context_includes_story_data(self):
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Phrase focus: slow down",
+            kind=ImprovementCard.KIND_PHRASE,
+            target_key="slow down",
+        )
+
+        response = self.client.get(reverse("practice:card_detail", args=[card.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("story_events", response.context)
+        self.assertIn("mastery_curve", response.context)
+        self.assertIn("review_stats", response.context)
 
 
 class PracticeWebTests(TransactionTestCase):
@@ -2404,7 +2527,8 @@ class PracticeWebTests(TransactionTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Drill: TH")
-        self.assertContains(response, "Review history")
+        self.assertContains(response, "How this card was earned")
+        self.assertContains(response, "Reviewed")
         self.assertContains(response, "Local template")
 
     def test_card_detail_shows_matching_mistake_snippets(self):

--- a/practice/tests.py
+++ b/practice/tests.py
@@ -29,6 +29,7 @@ from .models import (
 )
 from .context_processors import static_version
 from .services.jobs import create_scoring_job, process_scoring_job
+from .services.evidence import quality_for_card, session_quality
 from .services.scoring import score_transcript
 from .services.script_import import import_script_items, parse_csv_text, parse_json_text
 from .services.script_generation import (
@@ -1722,6 +1723,235 @@ class PracticeWebTests(TransactionTestCase):
         self.assertGreater(card.mastery, 0.2)
         self.assertIsNotNone(card.last_reviewed_at)
         self.assertGreater(card.due_at, timezone.now())
+
+    def test_word_card_review_uses_target_evidence_quality(self):
+        self._create_legacy_tables()
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: clear",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="clear",
+            prompt="Practice clear.",
+            mastery=0.2,
+        )
+        script = PracticeScript.objects.create(
+            user=self.user,
+            title="Clear Reps",
+            body="clear clear clear clear",
+            practice_kind=PracticeScript.KIND_DRILL,
+            source=PracticeScript.SOURCE_GENERATED,
+        )
+        GeneratedPracticeScript.objects.create(user=self.user, card=card, script=script)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "recording.txt"
+            path.write_text("clear clear clear", encoding="utf-8")
+            job = create_scoring_job(
+                user=self.user,
+                script=script,
+                audio_path=str(path),
+                provider="uploaded_transcript",
+            )
+            with patch("practice.services.jobs.refresh_improvement_cards"):
+                process_scoring_job(job.pk)
+
+        session = PracticeSession.objects.get()
+        card.refresh_from_db()
+        expected = round((4 / 7) * 0.75 + (3 / 7) * session_quality(session), 3)
+        review = PracticeReview.objects.get(card=card)
+        self.assertAlmostEqual(card.stats["last_review"]["quality"], expected, places=3)
+        self.assertEqual(card.stats["last_review"]["evidence"], {"opportunities": 4, "misses": 1})
+        self.assertAlmostEqual(review.error_rate, 0.25)
+        self.assertNotEqual(card.mastery, 0.2)
+
+    def test_word_card_without_target_evidence_gets_no_review(self):
+        self._create_legacy_tables()
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: clear",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="clear",
+            prompt="Practice clear.",
+            mastery=0.2,
+        )
+        script = PracticeScript.objects.create(
+            user=self.user,
+            title="Other Drill",
+            body="steady practice text",
+            practice_kind=PracticeScript.KIND_DRILL,
+            source=PracticeScript.SOURCE_GENERATED,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "recording.txt"
+            path.write_text("steady practice text", encoding="utf-8")
+            job = create_scoring_job(
+                user=self.user,
+                script=script,
+                audio_path=str(path),
+                provider="uploaded_transcript",
+                card=card,
+            )
+            with patch("practice.services.jobs.refresh_improvement_cards"):
+                process_scoring_job(job.pk)
+
+        card.refresh_from_db()
+        self.assertEqual(PracticeReview.objects.filter(card=card).count(), 0)
+        self.assertEqual(card.mastery, 0.2)
+
+    def test_ladder_step_script_reviews_only_ladder_cards_with_evidence(self):
+        self._create_legacy_tables()
+        alpha = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: alpha",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="alpha",
+            mastery=0.2,
+        )
+        beta = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: beta",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="beta",
+            mastery=0.2,
+        )
+        script = PracticeScript.objects.create(
+            user=self.user,
+            title="Alpha Ladder",
+            body="alpha alpha alpha",
+            practice_kind=PracticeScript.KIND_DRILL,
+            source=PracticeScript.SOURCE_GENERATED,
+        )
+        ladder = PracticeLadder.objects.create(user=self.user, title="Alpha Ladder")
+        ladder.cards.add(alpha, beta)
+        PracticeLadderStep.objects.create(ladder=ladder, script=script, level=1, title="Step 1")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "recording.txt"
+            path.write_text("alpha alpha alpha", encoding="utf-8")
+            job = create_scoring_job(
+                user=self.user,
+                script=script,
+                audio_path=str(path),
+                provider="uploaded_transcript",
+            )
+            with patch("practice.services.jobs.refresh_improvement_cards"):
+                process_scoring_job(job.pk)
+
+        self.assertEqual(PracticeReview.objects.filter(card=alpha).count(), 1)
+        self.assertEqual(PracticeReview.objects.filter(card=beta).count(), 0)
+
+    def test_multiple_generated_script_links_all_review_with_evidence(self):
+        self._create_legacy_tables()
+        alpha = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: alpha",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="alpha",
+            mastery=0.2,
+        )
+        beta = ImprovementCard.objects.create(
+            user=self.user,
+            title="Word focus: beta",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="beta",
+            mastery=0.2,
+        )
+        script = PracticeScript.objects.create(
+            user=self.user,
+            title="Linked Drill",
+            body="alpha beta alpha beta",
+            practice_kind=PracticeScript.KIND_DRILL,
+            source=PracticeScript.SOURCE_GENERATED,
+        )
+        GeneratedPracticeScript.objects.create(user=self.user, card=alpha, script=script)
+        GeneratedPracticeScript.objects.create(user=self.user, card=beta, script=script)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "recording.txt"
+            path.write_text("alpha beta alpha beta", encoding="utf-8")
+            job = create_scoring_job(
+                user=self.user,
+                script=script,
+                audio_path=str(path),
+                provider="uploaded_transcript",
+            )
+            with patch("practice.services.jobs.refresh_improvement_cards"):
+                process_scoring_job(job.pk)
+
+        self.assertEqual(PracticeReview.objects.filter(card=alpha).count(), 1)
+        self.assertEqual(PracticeReview.objects.filter(card=beta).count(), 1)
+
+    def test_fluency_card_always_reviews_from_fluency_bands(self):
+        self._create_legacy_tables()
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Fluency focus",
+            kind=ImprovementCard.KIND_FLUENCY,
+            target_key="pacing",
+            mastery=0.2,
+        )
+        script = PracticeScript.objects.create(
+            user=self.user,
+            title="Fluency Drill",
+            body="steady pacing text",
+            practice_kind=PracticeScript.KIND_DRILL,
+            source=PracticeScript.SOURCE_GENERATED,
+        )
+        session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:00:00",
+            script_name=script.title,
+            script_text=script.body,
+            audio_path="recording.txt",
+            transcript=script.body,
+            wer=0.0,
+            score=5.0,
+            artic_rate=140.0,
+            pause_ratio=0.15,
+            filled_pauses=0.0,
+        )
+        job = create_scoring_job(
+            user=self.user,
+            script=script,
+            audio_path="recording.txt",
+            provider="uploaded_transcript",
+            card=card,
+        )
+        with (
+            patch("practice.services.jobs.transcribe_score_and_store", return_value=session),
+            patch("practice.services.jobs.materialized_audio") as materialized,
+            patch("practice.services.jobs.refresh_improvement_cards"),
+        ):
+            materialized.return_value.__enter__.return_value = "recording.txt"
+            materialized.return_value.__exit__.return_value = None
+            process_scoring_job(job.pk)
+
+        card.refresh_from_db()
+        self.assertEqual(PracticeReview.objects.filter(card=card).count(), 1)
+        self.assertEqual(card.stats["last_review"]["quality"], 1.0)
+        self.assertIsNone(card.stats["last_review"]["evidence"])
+
+    def test_quality_for_card_returns_none_for_phrase_card(self):
+        self._create_legacy_tables()
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Phrase focus",
+            kind=ImprovementCard.KIND_PHRASE,
+            target_key="steady pacing",
+        )
+        session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:00:00",
+            script_name="Phrase Drill",
+            script_text="steady pacing",
+            audio_path="recording.txt",
+            transcript="steady pacing",
+            wer=0.0,
+            score=5.0,
+        )
+
+        self.assertIsNone(quality_for_card(card, session, []))
 
     def test_practice_post_queues_scoring_job(self):
         script = PracticeScript.objects.create(

--- a/practice/tests.py
+++ b/practice/tests.py
@@ -34,6 +34,7 @@ from .services.script_import import import_script_items, parse_csv_text, parse_j
 from .services.script_generation import (
     _stream_response_text,
     generate_local_template,
+    parse_self_review_cards,
     parse_generated_ladder,
     parse_generated_script,
     script_generation_provider_choices,
@@ -571,7 +572,7 @@ class PracticeWebTests(TransactionTestCase):
         self.assertEqual(confusions[0]["to"], "cr")
         self.assertEqual(summary["words"]["recent_session_count"], 1)
 
-    def test_build_card_candidates_includes_phrase_focus(self):
+    def test_build_card_candidates_does_not_emit_phrase_focus(self):
         candidates = build_card_candidates(
             {
                 "words": {},
@@ -590,9 +591,78 @@ class PracticeWebTests(TransactionTestCase):
             }
         )
 
-        self.assertEqual(candidates[0]["kind"], ImprovementCard.KIND_PHRASE)
-        self.assertEqual(candidates[0]["target_key"], "steady breath today")
-        self.assertEqual(candidates[0]["mastery"], 0.5)
+        self.assertEqual(candidates, [])
+
+    def test_refresh_improvement_cards_preserves_existing_srs_state(self):
+        reviewed_at = timezone.now() - timezone.timedelta(days=2)
+        due_at = timezone.now() + timezone.timedelta(days=11)
+        card = ImprovementCard.objects.create(
+            user=self.user,
+            title="Old word focus",
+            kind=ImprovementCard.KIND_WORD,
+            target_key="steady",
+            prompt="Old prompt",
+            stats={"old": True},
+            mastery=0.91,
+            status=ImprovementCard.STATUS_MASTERED,
+            due_at=due_at,
+            last_reviewed_at=reviewed_at,
+        )
+        summary = {
+            "words": {
+                "top_trouble_words": [
+                    {
+                        "word": "steady",
+                        "error_rate": 0.8,
+                        "errors": 4,
+                        "attempts": 5,
+                    }
+                ]
+            },
+            "sounds": {},
+            "phrases": {},
+            "positions": {},
+        }
+
+        with patch("practice.services.analytics.trend_summary", return_value=summary):
+            created = refresh_improvement_cards(user=self.user, days=30)
+
+        self.assertEqual(created, 0)
+        card.refresh_from_db()
+        self.assertEqual(card.mastery, 0.91)
+        self.assertEqual(card.status, ImprovementCard.STATUS_MASTERED)
+        self.assertEqual(card.due_at, due_at)
+        self.assertEqual(card.last_reviewed_at, reviewed_at)
+        self.assertEqual(card.title, "steady")
+        self.assertEqual(card.prompt, "Practice short phrases that place 'steady' at the beginning, middle, and end of a sentence.")
+        self.assertEqual(card.stats["errors"], 4)
+        self.assertEqual(card.stats["source_window_days"], 30)
+
+    def test_refresh_improvement_cards_creates_new_cards_with_seeded_mastery(self):
+        summary = {
+            "words": {
+                "top_trouble_words": [
+                    {
+                        "word": "steady",
+                        "error_rate": 0.25,
+                        "errors": 1,
+                        "attempts": 4,
+                    }
+                ]
+            },
+            "sounds": {},
+            "phrases": {},
+            "positions": {},
+        }
+
+        with patch("practice.services.analytics.trend_summary", return_value=summary):
+            created = refresh_improvement_cards(user=self.user, days=30)
+
+        self.assertEqual(created, 1)
+        card = ImprovementCard.objects.get(user=self.user, target_key="steady")
+        self.assertEqual(card.mastery, 0.75)
+        self.assertEqual(card.status, ImprovementCard.STATUS_REVIEW)
+        self.assertGreater(card.due_at, timezone.now())
 
     def test_refresh_improvement_cards_records_exact_source_range(self):
         summary = {
@@ -621,6 +691,32 @@ class PracticeWebTests(TransactionTestCase):
         self.assertEqual(card.stats["source_window_start"], "2026-06-01")
         self.assertEqual(card.stats["source_window_end"], "2026-06-19")
         self.assertEqual(card.stats["source_window_label"], "2026-06-01 to 2026-06-19")
+
+    def test_self_review_card_parser_skips_phrase_rows(self):
+        session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-06-14T12:00:00",
+            script_name="Free Speak",
+            script_text="",
+            audio_path="recording.txt",
+            transcript="I clipped the phrase but practiced clarity.",
+        )
+
+        cards = parse_self_review_cards(
+            """
+            {
+              "cards": [
+                {"kind": "phrase", "target": "steady breath today", "title": "Phrase", "prompt": "Practice the phrase."},
+                {"kind": "word", "target": "steady", "title": "Steady", "prompt": "Practice steady."}
+              ]
+            }
+            """,
+            session=session,
+        )
+
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].kind, ImprovementCard.KIND_WORD)
+        self.assertEqual(cards[0].target_key, "steady")
 
     def test_generated_script_parser_handles_structured_output(self):
         title, body = parse_generated_script(

--- a/practice/tests.py
+++ b/practice/tests.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import tempfile
 import wave
+from datetime import timedelta
+from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from error_analytics import phrase_trend_summary
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.db import connection
 from django.db.utils import OperationalError
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -18,6 +21,7 @@ from django.utils import timezone
 from .models import (
     GeneratedPracticeScript,
     ImprovementCard,
+    LadderStepProgress,
     PracticeLadder,
     PracticeLadderStep,
     PracticeReview,
@@ -66,6 +70,29 @@ class PracticeWebTests(TransactionTestCase):
             wav.setsampwidth(2)
             wav.setframerate(sample_rate)
             wav.writeframes(silence)
+
+    def _create_ladder_with_steps(self, *, count: int = 3, min_clarity: float = 0.9):
+        ladder = PracticeLadder.objects.create(user=self.user, title="Gate Ladder")
+        steps = []
+        for level in range(1, count + 1):
+            script = PracticeScript.objects.create(
+                user=self.user,
+                title=f"Gate Level {level}",
+                body=f"gate level {level}",
+                practice_kind=PracticeScript.KIND_DRILL,
+                source=PracticeScript.SOURCE_GENERATED,
+                difficulty=level,
+            )
+            steps.append(
+                PracticeLadderStep.objects.create(
+                    ladder=ladder,
+                    script=script,
+                    level=level,
+                    title=f"Level {level}",
+                    min_clarity=min_clarity,
+                )
+            )
+        return ladder, steps
 
     def test_static_version_uses_app_css_mtime(self):
         version = static_version(None)["static_version"]
@@ -1840,6 +1867,271 @@ class PracticeWebTests(TransactionTestCase):
 
         self.assertEqual(PracticeReview.objects.filter(card=alpha).count(), 1)
         self.assertEqual(PracticeReview.objects.filter(card=beta).count(), 0)
+
+    def test_ladder_gate_annotation_tracks_open_locked_and_passed(self):
+        from .views import _annotate_gate_states
+
+        _ladder, steps = self._create_ladder_with_steps()
+
+        annotated = _annotate_gate_states(self.user, steps)
+        self.assertEqual([step.gate_state for step in annotated], ["open", "locked", "locked"])
+        self.assertEqual([step.best_clarity for step in annotated], [None, None, None])
+
+        LadderStepProgress.objects.create(
+            user=self.user,
+            step=steps[0],
+            attempts=1,
+            best_clarity=0.92,
+            passed_at=timezone.now(),
+            best_session_id=123,
+        )
+
+        annotated = _annotate_gate_states(self.user, steps)
+        self.assertEqual([step.gate_state for step in annotated], ["passed", "open", "locked"])
+        self.assertEqual(annotated[0].best_clarity, 0.92)
+
+    def test_scoring_job_updates_ladder_step_progress(self):
+        self._create_legacy_tables()
+        _ladder, steps = self._create_ladder_with_steps(count=1, min_clarity=0.85)
+
+        sessions = [
+            PracticeSession.objects.create(
+                user=self.user,
+                timestamp="2026-07-08T12:00:00",
+                script_name=steps[0].script.title,
+                script_text=steps[0].script.body,
+                audio_path="recording.txt",
+                transcript="gate level one",
+                wer=0.2,
+                clarity=0.8,
+                score=4.0,
+            ),
+            PracticeSession.objects.create(
+                user=self.user,
+                timestamp="2026-07-08T12:01:00",
+                script_name=steps[0].script.title,
+                script_text=steps[0].script.body,
+                audio_path="recording.txt",
+                transcript="gate level one",
+                wer=0.09,
+                clarity=0.91,
+                score=4.6,
+            ),
+            PracticeSession.objects.create(
+                user=self.user,
+                timestamp="2026-07-08T12:02:00",
+                script_name=steps[0].script.title,
+                script_text=steps[0].script.body,
+                audio_path="recording.txt",
+                transcript="gate level one",
+                wer=0.14,
+                clarity=0.86,
+                score=4.3,
+            ),
+        ]
+
+        with (
+            patch("practice.services.jobs.materialized_audio") as materialized,
+            patch("practice.services.jobs.transcribe_score_and_store", side_effect=sessions),
+            patch("practice.services.jobs.refresh_improvement_cards"),
+        ):
+            materialized.return_value.__enter__.return_value = "recording.txt"
+            materialized.return_value.__exit__.return_value = None
+            for _session in sessions:
+                job = create_scoring_job(
+                    user=self.user,
+                    script=steps[0].script,
+                    audio_path="recording.txt",
+                    provider="uploaded_transcript",
+                )
+                process_scoring_job(job.pk)
+
+        progress = LadderStepProgress.objects.get(user=self.user, step=steps[0])
+        self.assertEqual(progress.attempts, 3)
+        self.assertEqual(progress.best_clarity, 0.91)
+        self.assertEqual(progress.best_session_id, sessions[1].pk)
+        self.assertIsNotNone(progress.passed_at)
+
+    def test_practice_get_locked_level_falls_back_to_highest_unlocked_step(self):
+        _ladder, steps = self._create_ladder_with_steps()
+        LadderStepProgress.objects.create(
+            user=self.user,
+            step=steps[0],
+            attempts=1,
+            best_clarity=0.95,
+            passed_at=timezone.now(),
+            best_session_id=1,
+        )
+
+        response = self.client.get(
+            reverse("practice:practice"),
+            {
+                "mode": "quick",
+                "ladder": _ladder.pk,
+                "level": 3,
+                "script": steps[2].script.pk,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["selected_ladder_step"].pk, steps[1].pk)
+        self.assertEqual(response.context["selected_script"].pk, steps[1].script.pk)
+
+    def test_practice_post_locked_ladder_script_returns_json_error_without_job(self):
+        _ladder, steps = self._create_ladder_with_steps()
+        upload = SimpleUploadedFile("recording.txt", b"gate level two", content_type="text/plain")
+
+        response = self.client.post(
+            reverse("practice:practice"),
+            {
+                "mode": "quick",
+                "script": steps[1].script.pk,
+                "provider": "uploaded_transcript",
+                "audio": upload,
+            },
+            HTTP_ACCEPT="application/json",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json()["ok"])
+        self.assertEqual(response.json()["error"], "This ladder level is locked. Pass the previous level first.")
+        self.assertEqual(ScoringJob.objects.count(), 0)
+
+    def test_scoring_job_detail_exposes_unlocked_level_for_passing_session(self):
+        self._create_legacy_tables()
+        _ladder, steps = self._create_ladder_with_steps(count=2, min_clarity=0.85)
+        session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:00:00",
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording.txt",
+            transcript=steps[0].script.body,
+            clarity=0.9,
+            score=4.5,
+        )
+        LadderStepProgress.objects.create(
+            user=self.user,
+            step=steps[0],
+            attempts=1,
+            best_clarity=0.9,
+            passed_at=timezone.now(),
+            best_session_id=session.pk,
+        )
+        job = ScoringJob.objects.create(
+            user=self.user,
+            script=steps[0].script,
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording.txt",
+            provider="uploaded_transcript",
+            status=ScoringJob.STATUS_SUCCEEDED,
+            legacy_session_id=session.pk,
+        )
+
+        response = self.client.get(reverse("practice:scoring_job", args=[job.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["unlocked_level"], 2)
+
+        last_session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:01:00",
+            script_name=steps[1].script.title,
+            script_text=steps[1].script.body,
+            audio_path="recording.txt",
+            transcript=steps[1].script.body,
+            clarity=0.9,
+            score=4.5,
+        )
+        LadderStepProgress.objects.create(
+            user=self.user,
+            step=steps[1],
+            attempts=1,
+            best_clarity=0.9,
+            passed_at=timezone.now(),
+            best_session_id=last_session.pk,
+        )
+        last_job = ScoringJob.objects.create(
+            user=self.user,
+            script=steps[1].script,
+            script_name=steps[1].script.title,
+            script_text=steps[1].script.body,
+            audio_path="recording.txt",
+            provider="uploaded_transcript",
+            status=ScoringJob.STATUS_SUCCEEDED,
+            legacy_session_id=last_session.pk,
+        )
+
+        response = self.client.get(reverse("practice:scoring_job", args=[last_job.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["unlocked_level"])
+
+    def test_backfill_ladder_progress_rebuilds_historical_jobs(self):
+        self._create_legacy_tables()
+        _ladder, steps = self._create_ladder_with_steps(count=1, min_clarity=0.85)
+        first_session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:00:00",
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording-1.txt",
+            transcript=steps[0].script.body,
+            clarity=0.8,
+            score=4.0,
+        )
+        second_session = PracticeSession.objects.create(
+            user=self.user,
+            timestamp="2026-07-08T12:01:00",
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording-2.txt",
+            transcript=steps[0].script.body,
+            clarity=0.92,
+            score=4.8,
+        )
+        first_time = timezone.now() - timedelta(minutes=2)
+        second_time = timezone.now() - timedelta(minutes=1)
+        ScoringJob.objects.create(
+            user=self.user,
+            script=steps[0].script,
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording-1.txt",
+            provider="uploaded_transcript",
+            status=ScoringJob.STATUS_SUCCEEDED,
+            legacy_session_id=first_session.pk,
+            finished_at=first_time,
+        )
+        ScoringJob.objects.create(
+            user=self.user,
+            script=steps[0].script,
+            script_name=steps[0].script.title,
+            script_text=steps[0].script.body,
+            audio_path="recording-2.txt",
+            provider="uploaded_transcript",
+            status=ScoringJob.STATUS_SUCCEEDED,
+            legacy_session_id=second_session.pk,
+            finished_at=second_time,
+        )
+        LadderStepProgress.objects.create(
+            user=self.user,
+            step=steps[0],
+            attempts=99,
+            best_clarity=0.1,
+        )
+        out = StringIO()
+
+        call_command("backfill_ladder_progress", "--user", self.user.username, stdout=out)
+
+        progress = LadderStepProgress.objects.get(user=self.user, step=steps[0])
+        self.assertEqual(progress.attempts, 2)
+        self.assertEqual(progress.best_clarity, 0.92)
+        self.assertEqual(progress.best_session_id, second_session.pk)
+        self.assertIsNotNone(progress.passed_at)
+        self.assertIn("rows created 1, passes 1", out.getvalue())
 
     def test_multiple_generated_script_links_all_review_with_evidence(self):
         self._create_legacy_tables()

--- a/practice/views.py
+++ b/practice/views.py
@@ -39,6 +39,7 @@ from .forms import (
 from .models import (
     GeneratedPracticeScript,
     ImprovementCard,
+    LadderStepProgress,
     PracticeLadder,
     PracticeLadderStep,
     PracticeReview,
@@ -84,8 +85,17 @@ from .services.script_generation import (
     generate_script_draft,
     script_generation_provider_choices,
 )
+
 from .services.transcription import TranscriptResult
 from .services.transcription import clear_local_whisper_cache, provider_label
+
+LADDER_MIN_CLARITY_BY_LEVEL = {
+    1: 0.85,
+    2: 0.88,
+    3: 0.90,
+    4: 0.92,
+    5: 0.95,
+}
 
 
 @login_not_required
@@ -228,7 +238,25 @@ def practice_run(request):
             audio = form.cleaned_data["audio"]
             provider = form.cleaned_data.get("provider") or None
             provider_name = provider or django_settings.TRANSCRIPTION_PROVIDER
-            if audio is None:
+            locked_ladder_step = (
+                _locked_ladder_step_for_script(request.user, script)
+                if mode == PracticeRunForm.MODE_QUICK and script is not None
+                else None
+            )
+            if locked_ladder_step is not None:
+                error = "This ladder level is locked. Pass the previous level first."
+                form.add_error("script", error)
+                if _wants_json(request):
+                    return JsonResponse(
+                        {
+                            "ok": False,
+                            "error": error,
+                            "errors": form.errors.get_json_data(escape_html=True),
+                        },
+                        status=400,
+                    )
+                messages.error(request, error)
+            elif audio is None:
                 form.add_error("audio", "Record or upload audio before scoring.")
             else:
                 audio_path = save_uploaded_audio(
@@ -320,13 +348,29 @@ def practice_run(request):
                 script=initial_script,
             )
             if selected_ladder is not None:
-                ladder_steps = _ladder_steps(selected_ladder)
+                ladder_steps = _annotate_gate_states(request.user, _ladder_steps(selected_ladder))
                 selected_ladder_step = _select_ladder_step(
                     ladder_steps,
                     requested_level=requested_level,
                     script=initial_script,
                 )
-                if initial_script is None and selected_ladder_step is not None:
+                if selected_ladder_step is not None and selected_ladder_step.gate_state == "locked":
+                    locked_step = selected_ladder_step
+                    selected_ladder_step = _highest_non_locked_step(ladder_steps)
+                    explicitly_requested_locked = requested_level == locked_step.level or (
+                        script_id and str(script_id) == str(locked_step.script_id)
+                    )
+                    if explicitly_requested_locked:
+                        previous_step = _previous_ladder_step(ladder_steps, locked_step)
+                        if previous_step is not None:
+                            messages.info(
+                                request,
+                                (
+                                    f"Level {locked_step.level} is locked - pass level "
+                                    f"{previous_step.level} with {int(previous_step.min_clarity * 100)}% clarity first."
+                                ),
+                            )
+                if selected_ladder_step is not None:
                     initial_script = selected_ladder_step.script
             if initial_script is None and quick_queue:
                 initial_card = quick_queue[0].card
@@ -378,6 +422,12 @@ def practice_run(request):
         selected_ladder = _select_ladder_for_request(practice_ladders, script=selected_script)
         if selected_ladder is not None:
             ladder_steps = _ladder_steps(selected_ladder)
+            selected_ladder_step = _select_ladder_step(ladder_steps, script=selected_script)
+    if mode == PracticeRunForm.MODE_QUICK and selected_ladder is not None:
+        if not ladder_steps:
+            ladder_steps = _ladder_steps(selected_ladder)
+        ladder_steps = _annotate_gate_states(request.user, ladder_steps)
+        if selected_ladder_step is None:
             selected_ladder_step = _select_ladder_step(ladder_steps, script=selected_script)
     context = {
         "form": form,
@@ -632,6 +682,7 @@ def scoring_job_detail(request, pk: int):
     context = {
         "job": job,
         "session": session,
+        "unlocked_level": _unlocked_level_for_job_session(job, session),
         **job_status_context(job),
     }
     return render(request, "practice/scoring_job.html", context)
@@ -1222,6 +1273,7 @@ def generate_practice_ladder(request):
             level=level,
             title=level_draft.title,
             focus=list(level_draft.focus),
+            min_clarity=LADDER_MIN_CLARITY_BY_LEVEL.get(level, 0.95),
         )
         created_steps.append(step)
         for card in cards:
@@ -1505,6 +1557,88 @@ def _ladder_steps(ladder: PracticeLadder) -> list[PracticeLadderStep]:
         .filter(script__active=True)
         .order_by("level")
     )
+
+
+def _annotate_gate_states(user, steps: list[PracticeLadderStep]) -> list[PracticeLadderStep]:
+    progress_by_step = {
+        progress.step_id: progress
+        for progress in LadderStepProgress.objects.filter(
+            user=user,
+            step_id__in=[step.pk for step in steps],
+        )
+    }
+    previous_passed = False
+    for index, step in enumerate(steps):
+        progress = progress_by_step.get(step.pk)
+        passed = bool(progress and progress.passed_at)
+        unlocked = index == 0 or previous_passed
+        step.gate_state = "passed" if passed else ("open" if unlocked else "locked")
+        step.best_clarity = (
+            float(progress.best_clarity)
+            if progress is not None and progress.attempts > 0
+            else None
+        )
+        previous_passed = passed
+    return steps
+
+
+def _highest_non_locked_step(steps: list[PracticeLadderStep]) -> PracticeLadderStep | None:
+    available = [step for step in steps if getattr(step, "gate_state", None) != "locked"]
+    return available[-1] if available else None
+
+
+def _previous_ladder_step(
+    steps: list[PracticeLadderStep],
+    step: PracticeLadderStep,
+) -> PracticeLadderStep | None:
+    for index, candidate in enumerate(steps):
+        if candidate.pk == step.pk:
+            return steps[index - 1] if index > 0 else None
+    return None
+
+
+def _locked_ladder_step_for_script(user, script: PracticeScript) -> PracticeLadderStep | None:
+    ladder_ids = list(
+        PracticeLadderStep.objects.filter(
+            script=script,
+            ladder__active=True,
+        )
+        .filter(models.Q(ladder__user=user) | models.Q(ladder__user__isnull=True))
+        .values_list("ladder_id", flat=True)
+        .distinct()
+    )
+    for ladder in PracticeLadder.objects.filter(pk__in=ladder_ids).order_by("source", "-created_at", "title"):
+        steps = _annotate_gate_states(user, _ladder_steps(ladder))
+        for step in steps:
+            if step.script_id == script.pk and step.gate_state == "locked":
+                return step
+    return None
+
+
+def _unlocked_level_for_job_session(job: ScoringJob, session: PracticeSession | None) -> int | None:
+    if job.status != ScoringJob.STATUS_SUCCEEDED or session is None or job.script_id is None:
+        return None
+    steps = list(
+        job.script.ladder_steps.select_related("ladder")
+        .filter(ladder__active=True)
+        .order_by("ladder_id", "level")
+    )
+    for step in steps:
+        progress = LadderStepProgress.objects.filter(user=job.user, step=step).first()
+        if not progress or not progress.passed_at or progress.best_session_id != session.pk:
+            continue
+        next_step = (
+            PracticeLadderStep.objects.filter(
+                ladder=step.ladder,
+                level=step.level + 1,
+                script__active=True,
+            )
+            .order_by("level")
+            .first()
+        )
+        if next_step is not None:
+            return next_step.level
+    return None
 
 
 def _select_ladder_step(

--- a/practice/views.py
+++ b/practice/views.py
@@ -1138,6 +1138,7 @@ def card_detail(request, pk: int):
         practice_kind=PracticeScript.KIND_DRILL,
     ).distinct()[:8]
     evidence_rows = _card_evidence_rows(card)
+    story_context = _card_story(card)
     return render(
         request,
         "practice/card_detail.html",
@@ -1147,8 +1148,198 @@ def card_detail(request, pk: int):
             "generated_scripts": generated_scripts,
             "evidence_rows": evidence_rows,
             "generation_provider_choices": script_generation_provider_choices(request.user),
+            **story_context,
         },
     )
+
+
+def _card_story(card: ImprovementCard) -> dict:
+    reviews = list(PracticeReview.objects.filter(user=card.user, card=card).order_by("reviewed_at", "pk"))
+    generations = list(
+        GeneratedPracticeScript.objects.filter(
+            user=card.user,
+            card=card,
+            script__isnull=False,
+        )
+        .select_related("script")
+        .order_by("created_at", "pk")
+    )
+    ladders = list(
+        PracticeLadder.objects.filter(
+            models.Q(user=card.user) | models.Q(user__isnull=True),
+            active=True,
+            cards=card,
+        )
+        .distinct()
+        .order_by("created_at", "pk")
+    )
+
+    source_label = str((card.stats or {}).get("source_window_label") or "").strip()
+    events = [
+        {
+            "kind": "created",
+            "at": card.created_at,
+            "title": "Spotted",
+            "detail": f"Flagged from {source_label}" if source_label else "Flagged for practice",
+            "url": None,
+        }
+    ]
+
+    practice_url = reverse("practice:practice")
+    events.extend(_card_story_drill_events(generations, practice_url, card.pk))
+    events.extend(
+        {
+            "kind": "ladder",
+            "at": ladder.created_at,
+            "title": "Added to ladder",
+            "detail": ladder.title,
+            "url": f"{practice_url}?mode=quick&ladder={ladder.pk}",
+        }
+        for ladder in ladders
+    )
+    events.extend(_card_story_review_events(reviews))
+
+    if card.status == ImprovementCard.STATUS_MASTERED:
+        events.append(
+            {
+                "kind": "mastered",
+                "at": card.last_reviewed_at or card.updated_at,
+                "title": "Mastered",
+                "detail": f"Mastery {float(card.mastery or 0.0):.2f}",
+                "url": None,
+            }
+        )
+
+    events.sort(key=lambda event: (event["at"], event["kind"], event["title"]))
+    return {
+        "story_events": events,
+        "mastery_curve": _card_mastery_curve(card, reviews),
+        "review_stats": _card_review_stats(reviews),
+    }
+
+
+def _card_story_drill_events(generations: list[GeneratedPracticeScript], practice_url: str, card_pk: int) -> list[dict]:
+    if len(generations) > 6:
+        skipped_count = len(generations) - 5
+        visible = [
+            *generations[:2],
+            {
+                "synthetic": True,
+                "at": generations[2].created_at,
+                "count": skipped_count,
+            },
+            *generations[-3:],
+        ]
+    else:
+        visible = generations
+
+    events = []
+    for generation in visible:
+        if isinstance(generation, dict):
+            events.append(
+                {
+                    "kind": "drill",
+                    "at": generation["at"],
+                    "title": "More drills",
+                    "detail": f"{generation['count']} more drills generated",
+                    "url": None,
+                }
+            )
+            continue
+        events.append(
+            {
+                "kind": "drill",
+                "at": generation.created_at,
+                "title": "Drill generated",
+                "detail": generation.script.title,
+                "url": f"{practice_url}?mode=quick&script={generation.script_id}&card={card_pk}",
+            }
+        )
+    return events
+
+
+def _card_story_review_events(reviews: list[PracticeReview]) -> list[dict]:
+    if len(reviews) > 8:
+        skipped_count = len(reviews) - 6
+        visible = [
+            *reviews[:2],
+            {
+                "synthetic": True,
+                "at": reviews[2].reviewed_at,
+                "count": skipped_count,
+            },
+            *reviews[-4:],
+        ]
+    else:
+        visible = reviews
+
+    events = []
+    for review in visible:
+        if isinstance(review, dict):
+            events.append(
+                {
+                    "kind": "review",
+                    "at": review["at"],
+                    "title": "More reviews",
+                    "detail": f"{review['count']} more reviews",
+                    "url": None,
+                }
+            )
+            continue
+        parts = []
+        if review.quality is not None:
+            parts.append(f"Quality {review.quality:.2f}")
+        if review.error_rate is not None:
+            parts.append(f"target error rate {int(round(review.error_rate * 100))}%")
+        events.append(
+            {
+                "kind": "review",
+                "at": review.reviewed_at,
+                "title": "Reviewed",
+                "detail": " - ".join(parts) if parts else "Review logged",
+                "url": None,
+            }
+        )
+    return events
+
+
+def _card_mastery_curve(card: ImprovementCard, reviews: list[PracticeReview]) -> dict | None:
+    points = [review for review in reviews if review.mastery_after is not None]
+    if len(points) < 2:
+        return None
+
+    span = len(points) - 1
+    coords = []
+    for index, review in enumerate(points):
+        mastery = max(0.0, min(1.0, float(review.mastery_after or 0.0)))
+        x = round(20 + (560 * index / span), 1)
+        y = round(140 - (120 * mastery), 1)
+        coords.append((x, y))
+
+    crosses_year = points[0].reviewed_at.year != points[-1].reviewed_at.year
+    date_format = "%b %d, %Y" if crosses_year else "%b %d"
+    return {
+        "viewbox": "0 0 600 160",
+        "points": " ".join(f"{x:.1f},{y:.1f}" for x, y in coords),
+        "last_x": coords[-1][0],
+        "last_y": coords[-1][1],
+        "start_label": points[0].reviewed_at.strftime(date_format),
+        "end_label": points[-1].reviewed_at.strftime(date_format),
+        "current_mastery": float(card.mastery or 0.0),
+    }
+
+
+def _card_review_stats(reviews: list[PracticeReview]) -> dict:
+    evidence_reviews = [review for review in reviews if review.evidence is not None]
+    evidence_error_rates = [review.error_rate for review in evidence_reviews if review.error_rate is not None]
+    return {
+        "count": len(reviews),
+        "evidence_count": len(evidence_reviews),
+        "first_at": reviews[0].reviewed_at if reviews else None,
+        "last_at": reviews[-1].reviewed_at if reviews else None,
+        "first_error_rate": evidence_error_rates[0] if evidence_error_rates else None,
+        "latest_error_rate": evidence_error_rates[-1] if evidence_error_rates else None,
+    }
 
 
 @require_POST

--- a/static/practice/app.css
+++ b/static/practice/app.css
@@ -4105,3 +4105,139 @@ button.qc-btn {
     flex: 1 1 auto;
   }
 }
+
+/* --- Clarity-gated ladder rungs (extends .ladder-level-links, lines 1791+) --- */
+.ladder-rungs {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+/* two-class selector (0,2,0) intentionally overrides legacy `.ladder-level-links a` (0,1,1) */
+.ladder-level-links .ladder-rung {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  height: auto;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--panel);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-weight: 500;
+  text-decoration: none;
+  place-items: initial;            /* undo legacy grid centering */
+  transition: border-color 0.15s ease, background 0.15s ease,
+              box-shadow 0.15s ease, transform 0.1s ease;
+}
+
+.ladder-rung-num {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--paper-deep);
+  color: var(--muted);
+  font-family: var(--font-num);
+  font-weight: 700;
+  font-size: 15px;
+}
+
+.ladder-rung-body {
+  display: grid;
+  gap: 1px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ladder-rung-title {
+  font-family: var(--font-display);
+  font-size: 15px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ladder-rung-state {
+  font-family: var(--font-num);
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.ladder-rung-tag {
+  flex: none;
+  border-radius: 999px;
+  padding: 3px 9px;
+  font-family: var(--font-num);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* passed */
+.ladder-rung.is-passed {
+  border-color: var(--grove);
+  background: var(--grove-tint);
+}
+.ladder-rung.is-passed .ladder-rung-num { background: var(--grove); color: #fff; }
+.ladder-rung.is-passed .ladder-rung-state { color: var(--grove-dark); }
+.ladder-rung-tag.is-passed { background: var(--grove); color: #fff; }
+
+/* open */
+.ladder-rung.is-open .ladder-rung-num { background: var(--clay-tint); color: var(--clay-dark); }
+.ladder-rung-tag.is-open { background: var(--gold-tint); color: var(--gold-ink); }
+
+/* locked (non-interactive div) */
+.ladder-rung.is-locked {
+  border-style: dashed;
+  border-color: var(--locked);
+  background: var(--paper-deep);
+  color: var(--muted);
+  cursor: default;
+}
+.ladder-rung.is-locked .ladder-rung-num {
+  background: transparent;
+  border: 2px dashed var(--locked);
+  color: var(--locked);
+}
+.ladder-rung.is-locked .ladder-rung-title { color: var(--muted); font-weight: 600; }
+.ladder-rung-tag.is-locked { background: transparent; border: 1px solid var(--locked); color: var(--muted); }
+
+/* interactive states — only real links (anchors). Scoped to beat legacy
+   `.ladder-level-links a:hover` (0,2,1) and `a.is-active` (0,1,1). */
+.ladder-level-links a.ladder-rung:hover {
+  border-color: var(--grove);
+  color: var(--ink);                 /* cancel legacy hover recolor to grove-dark */
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+.ladder-level-links a.ladder-rung:focus-visible {
+  outline: 2px solid var(--clay);
+  outline-offset: 2px;
+}
+.ladder-rung[aria-current="step"] {
+  border-color: var(--clay);
+  box-shadow: 0 0 0 3px var(--clay-tint);
+}
+
+/* ladder gate unlock callout (scoring results) */
+.ladder-unlock {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 12px;
+  padding: 11px 14px;
+  border: 1px solid var(--grove);
+  border-radius: 10px;
+  background: var(--grove-tint);
+  color: var(--grove-dark);
+  font-size: 14px;
+}
+.ladder-unlock strong { font-family: var(--font-display); color: var(--grove-dark); }
+.ladder-unlock-icon { flex: none; font-size: 18px; line-height: 1; }

--- a/static/practice/app.css
+++ b/static/practice/app.css
@@ -4241,3 +4241,216 @@ button.qc-btn {
 }
 .ladder-unlock strong { font-family: var(--font-display); color: var(--grove-dark); }
 .ladder-unlock-icon { flex: none; font-size: 18px; line-height: 1; }
+
+/* ============================================================
+   Card story page (card_detail.html)
+   ============================================================ */
+.story-headline {
+  display: grid;
+  gap: 16px;
+  margin-top: 18px;
+  padding: clamp(20px, 4vw, 32px);
+  border: 1px solid var(--line);
+  border-left: 7px solid var(--type-accent, var(--clay));
+  border-radius: var(--r-md);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.story-lede {
+  margin: 0;
+  max-width: 760px;
+  font-family: var(--font-display);
+  font-size: clamp(20px, 2.6vw, 30px);
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+.story-lede b {
+  font-weight: 700;
+  color: var(--type-accent, var(--grove-dark));
+  white-space: nowrap;
+}
+
+.story-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 28px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.story-facts li {
+  display: grid;
+  gap: 2px;
+}
+
+.story-facts span {
+  font-family: var(--font-num);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.story-facts strong {
+  font-family: var(--font-num);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ink);
+}
+
+/* ---- Mastery curve ---- */
+.mastery-panel .panel-heading {
+  margin-bottom: 14px;
+}
+
+.mastery-now {
+  font-family: var(--font-num);
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--grove-dark);
+}
+
+.curve-frame {
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--paper-deep);
+}
+
+.mastery-curve {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible; /* keep endpoint dot/halo from clipping at the edges */
+}
+
+.curve-line {
+  fill: none;
+  stroke: var(--grove);
+  stroke-width: 3;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.curve-dot-halo {
+  fill: var(--grove);
+  opacity: 0.16;
+}
+
+.curve-dot {
+  fill: var(--grove-dark);
+  stroke: var(--panel);
+  stroke-width: 2;
+}
+
+.curve-axis {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.curve-axis small {
+  font-family: var(--font-num);
+  color: var(--muted);
+}
+
+/* ---- Narrated story timeline (distinct from .timeline) ---- */
+.story-timeline {
+  position: relative;
+  display: grid;
+  gap: 2px;
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.story-timeline::before {
+  content: "";
+  position: absolute;
+  top: 12px;
+  bottom: 14px;
+  left: 8px;
+  width: 2px;
+  background: var(--line);
+}
+
+.story-event {
+  --node: var(--muted);
+  position: relative;
+  padding: 4px 2px 16px 34px;
+}
+
+.story-node {
+  position: absolute;
+  left: 1px;
+  top: 6px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--panel);
+  border: 3px solid var(--node);
+  box-shadow: var(--shadow-sm);
+}
+
+.story-event.is-created  { --node: var(--clay); }
+.story-event.is-drill    { --node: var(--grove); }
+.story-event.is-ladder   { --node: var(--gold); }
+.story-event.is-review   { --node: var(--grove-dark); }
+.story-event.is-mastered { --node: var(--gold); }
+
+.story-event.is-mastered .story-node {
+  background: var(--gold);
+  box-shadow: 0 0 0 4px var(--gold-tint), var(--shadow-sm);
+}
+
+.story-event-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+}
+
+.story-event-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+a.story-event-title {
+  text-decoration-line: underline;
+  text-decoration-color: var(--node);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+a.story-event-title:hover {
+  color: var(--node);
+}
+
+.story-when {
+  font-family: var(--font-num);
+  color: var(--muted);
+}
+
+.story-event-detail {
+  margin: 4px 0 0;
+  max-width: 720px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@media (max-width: 700px) {
+  .story-facts { gap: 12px 20px; }
+  .story-facts strong { font-size: 20px; }
+  .curve-frame { padding: 12px; }
+  .story-event { padding-left: 30px; }
+}

--- a/templates/practice/card_detail.html
+++ b/templates/practice/card_detail.html
@@ -41,17 +41,101 @@
   </div>
 </section>
 
+{# ---------- Story headline strip ---------- #}
+<section class="story-headline card-type-{{ card.kind }}">
+  <p class="eyebrow">The story so far</p>
+  <p class="story-lede">
+    {% if review_stats.latest_error_rate is not None %}
+      {% if review_stats.first_error_rate is not None and review_stats.count > 1 %}
+        Target error rate
+        {% if review_stats.latest_error_rate < review_stats.first_error_rate %}fell{% elif review_stats.latest_error_rate > review_stats.first_error_rate %}rose{% else %}held{% endif %}
+        from <b>{% widthratio review_stats.first_error_rate 1 100 %}%</b>
+        to <b>{% widthratio review_stats.latest_error_rate 1 100 %}%</b>
+        across {{ review_stats.count }} graded review{{ review_stats.count|pluralize }}.
+      {% else %}
+        First graded read landed at <b>{% widthratio review_stats.latest_error_rate 1 100 %}%</b> target error rate &mdash; the baseline to beat.
+      {% endif %}
+    {% else %}
+      This card is <b>spotted</b> and waiting for its first graded practice. Drill it to start the story.
+    {% endif %}
+  </p>
+  <ul class="story-facts">
+    <li><span>Mastery</span><strong>{% widthratio card.mastery 1 100 %}%</strong></li>
+    <li><span>Status</span><strong>{{ card.get_status_display }}</strong></li>
+    <li><span>Reviews</span><strong>{{ review_stats.count }}</strong></li>
+    <li><span>Evidence</span><strong>{{ review_stats.evidence_count }}</strong></li>
+    {% if card.due_at %}<li><span>Due</span><strong>{{ card.due_at|date:"M j" }}</strong></li>{% endif %}
+  </ul>
+</section>
+
+{# ---------- Mastery curve ---------- #}
+<section>
+  <article class="panel mastery-panel card-type-{{ card.kind }}">
+    <div class="panel-heading">
+      <p class="eyebrow">Mastery over time</p>
+      <span class="mastery-now">{% widthratio card.mastery 1 100 %}%</span>
+    </div>
+    {% if mastery_curve %}
+      <div class="curve-frame">
+        <svg class="mastery-curve" viewBox="{{ mastery_curve.viewbox }}" role="img"
+             aria-label="Mastery trend from {{ mastery_curve.start_label }} to {{ mastery_curve.end_label }}, now {% widthratio mastery_curve.current_mastery 1 100 %} percent">
+          <polyline class="curve-line" points="{{ mastery_curve.points }}" vector-effect="non-scaling-stroke" />
+          <circle class="curve-dot-halo" cx="{{ mastery_curve.last_x }}" cy="{{ mastery_curve.last_y }}" r="11" />
+          <circle class="curve-dot" cx="{{ mastery_curve.last_x }}" cy="{{ mastery_curve.last_y }}" r="5" />
+        </svg>
+      </div>
+      <div class="curve-axis">
+        <small>{{ mastery_curve.start_label }}</small>
+        <small>{{ mastery_curve.end_label }}</small>
+      </div>
+    {% else %}
+      <div class="meter"><span style="width: {% widthratio card.mastery 1 100 %}%"></span></div>
+      <p class="empty">Not enough graded reviews yet to chart a mastery curve. Practice a drill to plot the first point.</p>
+    {% endif %}
+  </article>
+</section>
+
+{# ---------- Narrated loop: spotted -> drilled -> improved -> mastered ---------- #}
+<section>
+  <article class="panel card-type-{{ card.kind }}">
+    <div class="panel-heading">
+      <p class="eyebrow">How this card was earned</p>
+      <span>{{ story_events|length }} moment{{ story_events|length|pluralize }}</span>
+    </div>
+    <ol class="story-timeline">
+      {% for event in story_events %}
+        <li class="story-event is-{{ event.kind }}">
+          <span class="story-node" aria-hidden="true"></span>
+          <div class="story-body">
+            <div class="story-event-head">
+              {% if event.url %}
+                <a class="story-event-title" href="{{ event.url }}">{{ event.title }}</a>
+              {% else %}
+                <strong class="story-event-title">{{ event.title }}</strong>
+              {% endif %}
+              <small class="story-when">{{ event.at|date:"M j, Y" }}</small>
+            </div>
+            {% if event.detail %}<p class="story-event-detail">{{ event.detail }}</p>{% endif %}
+          </div>
+        </li>
+      {% empty %}
+        <li class="story-event is-created">
+          <span class="story-node" aria-hidden="true"></span>
+          <div class="story-body">
+            <strong class="story-event-title">Spotted, ready to drill</strong>
+            <p class="story-event-detail">Generate a starter script or practice a drill and this timeline fills in: spotted, drilled, improved, mastered.</p>
+          </div>
+        </li>
+      {% endfor %}
+    </ol>
+  </article>
+</section>
+
+{# ---------- Evidence + generated drills ---------- #}
 <section class="dashboard-grid">
   <article class="panel">
-    <p class="eyebrow">Progress</p>
-    <div class="meter"><span style="width: {% widthratio card.mastery 1 100 %}%"></span></div>
-    <p>Mastery: {{ card.mastery|floatformat:2 }}</p>
-    <p>Status: {{ card.get_status_display }}</p>
-    <p>Due: {{ card.due_at }}</p>
-  </article>
-  <article class="panel">
     <div class="panel-heading">
-      <p class="eyebrow">Evidence</p>
+      <p class="eyebrow">Why it was spotted</p>
       <span>{{ evidence_rows|length }}</span>
     </div>
     <div class="evidence-list">
@@ -71,9 +155,7 @@
       {% endfor %}
     </div>
   </article>
-</section>
 
-<section class="dashboard-grid">
   <article class="panel">
     <div class="panel-heading">
       <p class="eyebrow">Generated drills</p>
@@ -87,24 +169,6 @@
         </a>
       {% empty %}
         <p class="empty">Generate a starter script to begin card-specific practice.</p>
-      {% endfor %}
-    </div>
-  </article>
-
-  <article class="panel">
-    <div class="panel-heading">
-      <p class="eyebrow">Review history</p>
-      <span>{{ reviews|length }}</span>
-    </div>
-    <div class="review-list">
-      {% for review in reviews %}
-        <div class="review-row">
-          <strong>{% if review.score %}{{ review.score|floatformat:2 }}{% else %}-{% endif %}</strong>
-          <span>WER {% if review.error_rate is not None %}{{ review.error_rate|floatformat:2 }}{% else %}-{% endif %}</span>
-          <small>{{ review.reviewed_at }}</small>
-        </div>
-      {% empty %}
-        <p class="empty">No card-specific reviews yet.</p>
       {% endfor %}
     </div>
   </article>

--- a/templates/practice/practice_run.html
+++ b/templates/practice/practice_run.html
@@ -114,11 +114,20 @@
 
         <div class="ladder-level-links" aria-label="Ladder levels">
           {% for step in ladder_steps %}
-            <a
-              class="{% if selected_ladder_step and selected_ladder_step.pk == step.pk %}is-active{% endif %}"
-              href="{% url 'practice:practice' %}?mode=quick&amp;ladder={{ selected_ladder.pk }}&amp;level={{ step.level }}&amp;script={{ step.script.pk }}"
-              title="{{ step.title }}"
-            >{{ step.level }}</a>
+            {% if step.gate_state == "locked" %}
+              <span
+                class="is-locked"
+                aria-disabled="true"
+                data-gate-state="{{ step.gate_state }}"
+              >{{ step.level }}</span>
+            {% else %}
+              <a
+                class="{% if selected_ladder_step and selected_ladder_step.pk == step.pk %}is-active{% endif %}"
+                href="{% url 'practice:practice' %}?mode=quick&amp;ladder={{ selected_ladder.pk }}&amp;level={{ step.level }}&amp;script={{ step.script.pk }}"
+                title="{{ step.title }}"
+                data-gate-state="{{ step.gate_state }}"
+              >{{ step.level }}</a>
+            {% endif %}
           {% empty %}
             <span class="empty">Run migrations or generate a ladder to load levels.</span>
           {% endfor %}

--- a/templates/practice/practice_run.html
+++ b/templates/practice/practice_run.html
@@ -112,21 +112,51 @@
           </div>
         {% endif %}
 
-        <div class="ladder-level-links" aria-label="Ladder levels">
+        <div class="ladder-level-links ladder-rungs" role="list" aria-label="Ladder levels">
           {% for step in ladder_steps %}
             {% if step.gate_state == "locked" %}
-              <span
-                class="is-locked"
-                aria-disabled="true"
-                data-gate-state="{{ step.gate_state }}"
-              >{{ step.level }}</span>
+              <div class="ladder-rung is-locked" role="listitem"
+                   data-gate-state="locked" aria-disabled="true" title="{{ step.title }}">
+                <span class="ladder-rung-num" aria-hidden="true">{{ step.level }}</span>
+                <span class="ladder-rung-body">
+                  <span class="ladder-rung-title">{{ step.title }}</span>
+                  <span class="ladder-rung-state">
+                    <span class="sr-only">Level {{ step.level }} locked. </span>
+                    Pass level {{ step.level|add:"-1" }} to unlock
+                  </span>
+                </span>
+                <span class="ladder-rung-tag is-locked" aria-hidden="true">Locked</span>
+              </div>
             {% else %}
-              <a
-                class="{% if selected_ladder_step and selected_ladder_step.pk == step.pk %}is-active{% endif %}"
-                href="{% url 'practice:practice' %}?mode=quick&amp;ladder={{ selected_ladder.pk }}&amp;level={{ step.level }}&amp;script={{ step.script.pk }}"
-                title="{{ step.title }}"
-                data-gate-state="{{ step.gate_state }}"
-              >{{ step.level }}</a>
+              <a class="ladder-rung is-{{ step.gate_state }}" role="listitem"
+                 data-gate-state="{{ step.gate_state }}"
+                 href="{% url 'practice:practice' %}?mode=quick&amp;ladder={{ selected_ladder.pk }}&amp;level={{ step.level }}&amp;script={{ step.script.pk }}"
+                 {% if selected_ladder_step and selected_ladder_step.pk == step.pk %}aria-current="step"{% endif %}
+                 title="{{ step.title }}">
+                <span class="ladder-rung-num" aria-hidden="true">{{ step.level }}</span>
+                <span class="ladder-rung-body">
+                  <span class="ladder-rung-title">{{ step.title }}</span>
+                  <span class="ladder-rung-state">
+                    {% if step.gate_state == "passed" %}
+                      <span class="sr-only">Level {{ step.level }} passed, best clarity </span>
+                      Passed &middot; {% widthratio step.best_clarity 1 100 %}%
+                    {% else %}
+                      {% if step.best_clarity %}
+                        <span class="sr-only">Level {{ step.level }} open, best attempt </span>
+                        Best {% widthratio step.best_clarity 1 100 %}% &middot;
+                      {% else %}
+                        <span class="sr-only">Level {{ step.level }} open. </span>
+                      {% endif %}
+                      needs {% widthratio step.min_clarity 1 100 %}%
+                    {% endif %}
+                  </span>
+                </span>
+                {% if step.gate_state == "passed" %}
+                  <span class="ladder-rung-tag is-passed" aria-hidden="true">{% widthratio step.best_clarity 1 100 %}%</span>
+                {% else %}
+                  <span class="ladder-rung-tag is-open" aria-hidden="true">Open</span>
+                {% endif %}
+              </a>
             {% endif %}
           {% empty %}
             <span class="empty">Run migrations or generate a ladder to load levels.</span>

--- a/templates/practice/scoring_job.html
+++ b/templates/practice/scoring_job.html
@@ -33,6 +33,13 @@
     {% if is_pending %}
       <p>This page refreshes automatically while transcription and scoring run.</p>
     {% elif is_done and session %}
+      {% if unlocked_level %}
+        <p class="ladder-unlock" role="status">
+          <span class="ladder-unlock-icon" aria-hidden="true">&#127942;</span>
+          <span><strong>Level {{ unlocked_level }} unlocked.</strong>
+          You cleared the clarity gate on level {{ unlocked_level|add:"-1" }}.</span>
+        </p>
+      {% endif %}
       <p>Scoring finished. Your improvement cards were refreshed{% if job.card %}, and this card's review schedule was updated{% endif %}.</p>
       <a class="button-link" href="{% url 'practice:session_detail' session.pk %}">Open scored session</a>
     {% elif is_failed %}


### PR DESCRIPTION
## What this is

Implements the "core loop" concept end to end: **measure → diagnose → treat → verify → retire**. Full design rationale and data contracts are in [docs/core-loop-plan.html](docs/core-loop-plan.html) (also committed here).

## What changed

**Phase 0 — analytics stops clobbering SRS state; phrase cards retired**
- `refresh_improvement_cards` now only updates `title`/`prompt`/`stats` on existing cards; `mastery`/`status`/`due_at` are seeded at creation only. Previously every scored session overwrote review-earned mastery seconds after it was granted.
- Phrase cards are no longer generated (trends or self-review); existing ones paused via data migration (history kept).

**Phase 1 — evidence-graded reviews with fan-out**
- New `practice/services/evidence.py`: each card is graded on its own target's per-session performance (word token hits, phoneme-symbol stats via `_phoneme_stats`, char/position events, fluency bands), blended with session quality by a shrinkage weight `w = opportunities/(opportunities+3)`. **No evidence in the take → no review for that card.**
- Scoring jobs now review the deduped union of: the explicit card, all `GeneratedPracticeScript` links (previously an arbitrary `.first()`), and the ladder's full card set. Ladder practice previously updated at most one arbitrary card.

**Phase 2 — clarity-gated ladder rungs**
- `PracticeLadderStep.min_clarity` (85→95% ramp across levels; existing steps migrated) and per-user `LadderStepProgress` (best clarity, attempts, passed_at).
- Rung N+1 unlocks when rung N is passed at its threshold. Enforced on GET (redirect + message), POST (rejects locked scripts), and in the template (locked rungs render non-clickable with the requirement shown).
- "Level N unlocked" callout on scoring results; `backfill_ladder_progress` management command rebuilds progress from historical jobs. **Temporarily wired into `build.sh` so the free Render instance backfills on deploy — remove that line after the first successful deploy.**

**Phase 3 — card story page**
- `PracticeReview` gains `quality`/`mastery_after`/`evidence`; legacy rows backfilled by parsing the auto-generated notes text (parser inlined in the migration).
- Card detail redesigned as a narrative: headline ("Target error rate fell from 22% to 5% across 3 graded reviews"), server-rendered SVG mastery curve, and a spotted→drilled→improved→mastered timeline.

## How it was built and verified

- Implementation delegated to Codex (gpt-5.5) per phase from detailed specs; ladder-gate and story-page UI designed by a Claude Opus subagent; all diffs reviewed, tests re-run, and UI verified in-browser (gate states, locked-level redirect/POST rejection, story page in populated and empty states).
- Test suite grew 85 → 111, all passing; `makemigrations --check` clean.

## Reviewer notes

- Three schema migrations (0015 pause phrase cards, 0016 ladder gating, 0017 review story fields) — all with data steps, all reverse-noop.
- Mastery/quality constants (0.82/0.62 quality gates, shrinkage k=3, 85→95 clarity ramp) are hand-tuned starting values, flagged in the plan doc for tuning after real use.
- Deploy order is safe: migrations run in `build.sh` before the backfill command.